### PR TITLE
Disabled KeyInfo functions

### DIFF
--- a/checks/remote_desktop_check_test.go
+++ b/checks/remote_desktop_check_test.go
@@ -3,7 +3,6 @@ package checks_test
 import (
 	"github.com/InfoSec-Agent/InfoSec-Agent/checks"
 	"github.com/InfoSec-Agent/InfoSec-Agent/registrymock"
-	"golang.org/x/sys/windows/registry"
 	"reflect"
 	"testing"
 )
@@ -65,51 +64,51 @@ func TestRemoteDesktopCheck(t *testing.T) {
 // Parameters: t (testing.T) - the testing framework
 //
 // Returns: _
-func TestRegistryOutputRemoteDesktop(t *testing.T) {
-	tests := []struct {
-		name  string
-		path  string
-		want  registry.KeyInfo
-		want2 []uint64
-	}{
-		{
-			name: "Terminal Server key",
-			path: `System\CurrentControlSet\Control\Terminal Server`,
-			// We do not assign a value to lastWritetime, since it can be overwritten by the system
-			want: registry.KeyInfo{
-				SubKeyCount:     11,
-				MaxSubKeyLen:    24,
-				ValueCount:      14,
-				MaxValueNameLen: 21,
-				MaxValueLen:     64},
-			want2: []uint64{0, 1},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			key, err := registry.OpenKey(registry.LOCAL_MACHINE, tt.path, registry.QUERY_VALUE)
-			if err != nil {
-				t.Fail()
-			}
-			defer func(key registry.Key) {
-				err := key.Close()
-				if err != nil {
-					t.Fail()
-				}
-			}(key)
-			res, err := key.Stat()
-			if !reflect.DeepEqual(res.SubKeyCount, tt.want.SubKeyCount) ||
-				!reflect.DeepEqual(res.MaxSubKeyLen, tt.want.MaxSubKeyLen) ||
-				!reflect.DeepEqual(res.ValueCount, tt.want.ValueCount) ||
-				!reflect.DeepEqual(res.MaxValueNameLen, tt.want.MaxValueNameLen) ||
-				!reflect.DeepEqual(res.MaxValueLen, tt.want.MaxValueLen) {
-				t.Errorf("Registry key info = %v, want %v", res, tt.want)
-			}
-			val, _, err := key.GetIntegerValue("fDenyTSConnections")
-			if !reflect.DeepEqual(val, tt.want2[0]) &&
-				!reflect.DeepEqual(val, tt.want2[1]) {
-				t.Errorf("Key integer value= %v, want %v or %v", val, tt.want2[0], tt.want2[1])
-			}
-		})
-	}
-}
+//func TestRegistryOutputRemoteDesktop(t *testing.T) {
+//	tests := []struct {
+//		name  string
+//		path  string
+//		want  registry.KeyInfo
+//		want2 []uint64
+//	}{
+//		{
+//			name: "Terminal Server key",
+//			path: `System\CurrentControlSet\Control\Terminal Server`,
+//			// We do not assign a value to lastWritetime, since it can be overwritten by the system
+//			want: registry.KeyInfo{
+//				SubKeyCount:     11,
+//				MaxSubKeyLen:    24,
+//				ValueCount:      14,
+//				MaxValueNameLen: 21,
+//				MaxValueLen:     64},
+//			want2: []uint64{0, 1},
+//		},
+//	}
+//	for _, tt := range tests {
+//		t.Run(tt.name, func(t *testing.T) {
+//			key, err := registry.OpenKey(registry.LOCAL_MACHINE, tt.path, registry.QUERY_VALUE)
+//			if err != nil {
+//				t.Fail()
+//			}
+//			defer func(key registry.Key) {
+//				err := key.Close()
+//				if err != nil {
+//					t.Fail()
+//				}
+//			}(key)
+//			res, err := key.Stat()
+//			if !reflect.DeepEqual(res.SubKeyCount, tt.want.SubKeyCount) ||
+//				!reflect.DeepEqual(res.MaxSubKeyLen, tt.want.MaxSubKeyLen) ||
+//				!reflect.DeepEqual(res.ValueCount, tt.want.ValueCount) ||
+//				!reflect.DeepEqual(res.MaxValueNameLen, tt.want.MaxValueNameLen) ||
+//				!reflect.DeepEqual(res.MaxValueLen, tt.want.MaxValueLen) {
+//				t.Errorf("Registry key info = %v, want %v", res, tt.want)
+//			}
+//			val, _, err := key.GetIntegerValue("fDenyTSConnections")
+//			if !reflect.DeepEqual(val, tt.want2[0]) &&
+//				!reflect.DeepEqual(val, tt.want2[1]) {
+//				t.Errorf("Key integer value= %v, want %v or %v", val, tt.want2[0], tt.want2[1])
+//			}
+//		})
+//	}
+//}

--- a/checks/windows_loginmethod_test.go
+++ b/checks/windows_loginmethod_test.go
@@ -101,44 +101,44 @@ func TestLoginMethod(t *testing.T) {
 // Parameters: t (testing.T) - the testing framework
 //
 // Returns: _
-func TestRegistryOutputLoginMethod(t *testing.T) {
-	tests := []struct {
-		name string
-		path string
-		want registry.KeyInfo
-	}{
-		{
-			name: "UserTitle key",
-			path: `SOFTWARE\Microsoft\Windows\CurrentVersion\Authentication\LogonUI\UserTile`,
-			// We do not assign a value to lastWritetime, since it can be overwritten by the system
-			want: registry.KeyInfo{
-				SubKeyCount:     0,
-				MaxSubKeyLen:    0,
-				ValueCount:      2,
-				MaxValueNameLen: 46,
-				MaxValueLen:     78},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			key, err := registry.OpenKey(registry.LOCAL_MACHINE, tt.path, registry.QUERY_VALUE)
-			if err != nil {
-				t.Fail()
-			}
-			defer func(key registry.Key) {
-				err := key.Close()
-				if err != nil {
-					t.Fail()
-				}
-			}(key)
-			res, err := key.Stat()
-			if !reflect.DeepEqual(res.SubKeyCount, tt.want.SubKeyCount) ||
-				!reflect.DeepEqual(res.MaxSubKeyLen, tt.want.MaxSubKeyLen) ||
-				!reflect.DeepEqual(res.ValueCount, tt.want.ValueCount) ||
-				!reflect.DeepEqual(res.MaxValueNameLen, tt.want.MaxValueNameLen) ||
-				!reflect.DeepEqual(res.MaxValueLen, tt.want.MaxValueLen) {
-				t.Errorf("Registry key info = %v, want %v", res, tt.want)
-			}
-		})
-	}
-}
+//func TestRegistryOutputLoginMethod(t *testing.T) {
+//	tests := []struct {
+//		name string
+//		path string
+//		want registry.KeyInfo
+//	}{
+//		{
+//			name: "UserTitle key",
+//			path: `SOFTWARE\Microsoft\Windows\CurrentVersion\Authentication\LogonUI\UserTile`,
+//			// We do not assign a value to lastWritetime, since it can be overwritten by the system
+//			want: registry.KeyInfo{
+//				SubKeyCount:     0,
+//				MaxSubKeyLen:    0,
+//				ValueCount:      2,
+//				MaxValueNameLen: 46,
+//				MaxValueLen:     78},
+//		},
+//	}
+//	for _, tt := range tests {
+//		t.Run(tt.name, func(t *testing.T) {
+//			key, err := registry.OpenKey(registry.LOCAL_MACHINE, tt.path, registry.QUERY_VALUE)
+//			if err != nil {
+//				t.Fail()
+//			}
+//			defer func(key registry.Key) {
+//				err := key.Close()
+//				if err != nil {
+//					t.Fail()
+//				}
+//			}(key)
+//			res, err := key.Stat()
+//			if !reflect.DeepEqual(res.SubKeyCount, tt.want.SubKeyCount) ||
+//				!reflect.DeepEqual(res.MaxSubKeyLen, tt.want.MaxSubKeyLen) ||
+//				!reflect.DeepEqual(res.ValueCount, tt.want.ValueCount) ||
+//				!reflect.DeepEqual(res.MaxValueNameLen, tt.want.MaxValueNameLen) ||
+//				!reflect.DeepEqual(res.MaxValueLen, tt.want.MaxValueLen) {
+//				t.Errorf("Registry key info = %v, want %v", res, tt.want)
+//			}
+//		})
+//	}
+//}


### PR DESCRIPTION
Turns out registry keys are unique per user and therefore can not be evaluated for equality. Have to figure out another way to tests this.