### PR TITLE
V24A-401 Added log level flag

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -7,47 +7,88 @@ import (
 	"os"
 )
 
+// Constants representing the log levels for the logger.
+// These constants are used to set the LogLevel and LogLevelSpecific fields of the CustomLogger struct.
+// TraceLevel represents the lowest level of logs, used for detailed information about program execution.
+// DebugLevel is used for information that may be helpful in diagnosing problems.
+// InfoLevel is for general operational information about the program.
+// WarningLevel is for information about events that may indicate a problem.
+// ErrorLevel is for reporting errors that occur during program execution.
+// FatalLevel is for reporting severe errors that may prevent program execution.
+const (
+	TraceLevel = iota
+	DebugLevel
+	InfoLevel
+	WarningLevel
+	ErrorLevel
+	FatalLevel
+)
+
 var (
 	Log *CustomLogger
 )
 
 // CustomLogger is a custom logger struct that wraps the standard logger.
-// TODO: fix this docstring according to new documentation standard
 // It implements 6 error levels: Trace, Debug, Info, Warning, Error, and Fatal.
+// LogLevel determines the maximum level of messages that will be logged.
+// LogLevelSpecific determines the specific level of messages that will be logged.
+// If LogLevelSpecific is set to a log-level value, then only that log-level will be written to the log file.
+// If LogLevelSpecific is set to -1, then all log-levels up to the specified LogLevel will be written to the log file.
 type CustomLogger struct {
 	*log.Logger
+	LogLevel         int
+	LogLevelSpecific int
 }
 
 // Setup initializes a new logger for the runtime of the application
-// TODO: fix this docstring according to new documentation standard
-// Parameters: _
 //
-// Returns: _
-func Setup() {
-	Log = NewCustomLogger(false)
+// This function is used to set up the logger with a specific log level and a specific log level filter.
+//
+// Parameters:
+//
+// logLevel int - The log level to log up to. This should be a value between 0 (TraceLevel) and 5 (FatalLevel).
+//
+// logLevelSpecific int - The specific log level to log. This should be a value between
+// 0 (TraceLevel) and 5 (FatalLevel), or -1 to log all levels up to the specified log level.
+//
+// Returns: None
+func Setup(logLevel int, logLevelSpecific int) {
+	Log = NewCustomLogger(false, logLevel, logLevelSpecific)
 }
 
-// SetupTests initializes a logger for the runtime of the tests
-// This logger does not write to a file, but simply writes to standard output
-// TODO: fix this docstring according to new documentation standard
-// Parameters: _
+// SetupTests initializes a logger for the runtime of the tests.
 //
-// Returns: _
+// This function is used to set up the logger with a specific log level and a specific log level filter.
+// The log level is set to 0 (TraceLevel) and the log level specific is set to -1, meaning all log levels will be logged.
+// This logger does not write to a file, but simply writes to standard output.
+//
+// Parameters: None
+//
+// Returns: None
 func SetupTests() {
-	Log = NewCustomLogger(true)
+	Log = NewCustomLogger(true, 0, -1)
 }
 
 // NewCustomLogger creates a new CustomLogger struct.
-// The parameter test can specify whether the logger should write to a file.
+//
+// This function is used to create a new CustomLogger with a specific log level and a specific log level filter.
+// The test parameter determines whether the logger should write to a file or to standard output.
 // During testing, we wish for the logger to write to standard output.
-// TODO: fix this docstring according to new documentation standard
-// Parameters: test bool - a boolean value that specifies whether the logger is used for testing
+//
+// Parameters:
+//
+// test bool - A boolean value that specifies whether the logger is used for testing.
+//
+// logLevel int - The log level to log up to. This should be a value between 0 (TraceLevel) and 5 (FatalLevel).
+//
+// logLevelSpecific int - The specific log level to log. This should be a value between 0 (TraceLevel) and 5 (FatalLevel), or -1 to log all levels up to the specified log level.
 //
 // Returns: a pointer to a new CustomLogger struct
-func NewCustomLogger(test bool) *CustomLogger {
+func NewCustomLogger(test bool, logLevel int, logLevelSpecific int) *CustomLogger {
 	if test {
 		return &CustomLogger{
-			Logger: log.New(os.Stdout, "", log.LstdFlags),
+			Logger:   log.New(os.Stdout, "", log.LstdFlags),
+			LogLevel: logLevel,
 		}
 	}
 	file, err := os.OpenFile("log.txt", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0666)
@@ -55,91 +96,153 @@ func NewCustomLogger(test bool) *CustomLogger {
 		log.Fatal(err)
 	}
 	return &CustomLogger{
-		Logger: log.New(file, "", log.LstdFlags),
+		Logger:           log.New(file, "", log.LstdFlags),
+		LogLevel:         logLevel,
+		LogLevelSpecific: logLevelSpecific,
 	}
 }
 
-// Print writes a message to the log file
-// TODO: fix this docstring according to new documentation standard
-// Parameters: message string - the message to write to the log file
+// Print writes a general message to the log file.
 //
-// Returns: _
+// This method is used to write a message to the log file. The message is not associated with any specific log level.
+//
+// Parameters:
+//
+// message string - The message to write to the log file.
+//
+// Returns: None
 func (l *CustomLogger) Print(message string) {
 	l.Println(message)
 }
 
-// Trace writes a trace level message to the log file
-// TODO: fix this docstring according to new documentation standard
-// Parameters: message string - the message to write to the log file
+// Trace writes a trace level message to the log file.
 //
-// Returns: _
+// The message will only be logged if the LogLevelSpecific of the logger is set to TraceLevel,
+// or if the LogLevelSpecific is set to -1 and the LogLevel is less than or equal to TraceLevel.
+//
+// Parameters:
+//
+// message string - The message to write to the log file.
+//
+// Returns: None
 func (l *CustomLogger) Trace(message string) {
-	l.Println("TRACE: " + message)
+	if l.LogLevelSpecific == -1 && l.LogLevel <= TraceLevel || l.LogLevelSpecific == TraceLevel {
+		l.Println("TRACE: " + message)
+	}
 }
 
-// Debug writes a debug level message to the log file
-// TODO: fix this docstring according to new documentation standard
-// Parameters: message string - the message to write to the log file
+// Debug writes a debug level message to the log file.
 //
-// Returns: _
+// The message will only be logged if the LogLevelSpecific of the logger is set to DebugLevel,
+// or if the LogLevelSpecific is set to -1 and the LogLevel is less than or equal to DebugLevel.
+//
+// Parameters:
+//
+// message string - The message to write to the log file.
+//
+// Returns: None
 func (l *CustomLogger) Debug(message string) {
-	l.Println("DEBUG: " + message)
+	if l.LogLevelSpecific == -1 && l.LogLevel <= DebugLevel || l.LogLevelSpecific == DebugLevel {
+		l.Println("DEBUG: " + message)
+	}
 }
 
-// Info writes an info level message to the log file
-// TODO: fix this docstring according to new documentation standard
-// Parameters: message string - the message to write to the log file
+// Info writes an info level message to the log file.
 //
-// Returns: _
+// The message will only be logged if the LogLevelSpecific of the logger is set to InfoLevel,
+// or if the LogLevelSpecific is set to -1 and the LogLevel is less than or equal to Info.
+//
+// Parameters:
+//
+// message string - The message to write to the log file.
+//
+// Returns: None
 func (l *CustomLogger) Info(message string) {
-	l.Println("INFO: " + message)
+	if l.LogLevelSpecific == -1 && l.LogLevel <= InfoLevel || l.LogLevelSpecific == InfoLevel {
+		l.Println("INFO: " + message)
+	}
 }
 
-// Warning writes a warning level message to the log file
-// TODO: fix this docstring according to new documentation standard
-// Parameters: message string - the message to write to the log file
+// Warning writes a warning level message to the log file.
 //
-// Returns: _
+// The message will only be logged if the LogLevelSpecific of the logger is set to WarningLevel,
+// or if the LogLevelSpecific is set to -1 and the LogLevel is less than or equal to WarningLevel.
+//
+// Parameters:
+//
+// message string - The message to write to the log file.
+//
+// Returns: None
 func (l *CustomLogger) Warning(message string) {
-	l.Println("WARNING: " + message)
+	if l.LogLevelSpecific == -1 && l.LogLevel <= WarningLevel || l.LogLevelSpecific == WarningLevel {
+		l.Println("WARNING: " + message)
+	}
 }
 
-// Error writes an error level message to the log file
-// TODO: fix this docstring according to new documentation standard
-// Parameters: message string - the message to write to the log file
+// Error writes an error level message to the log file.
 //
-// Returns: _
+// The message will only be logged if the LogLevelSpecific of the logger is set to ErrorLevel,
+// or if the LogLevelSpecific is set to -1 and the LogLevel is less than or equal to ErrorLevel.
+//
+// Parameters:
+//
+// message string - The message to write to the log file.
+//
+// Returns: None
 func (l *CustomLogger) Error(message string) {
-	l.Println("ERROR: " + message)
+	if l.LogLevelSpecific == -1 && l.LogLevel <= ErrorLevel || l.LogLevelSpecific == ErrorLevel {
+		l.Println("ERROR: " + message)
+	}
 }
 
-// ErrorWithErr writes an error level message to the log file, including the error variable
-// TODO: fix this docstring according to new documentation standard
-// Parameters: message string - the message to write to the log file
+// ErrorWithErr writes an error level message to the log file, including the error variable.
 //
-// err error - the error variable to write to the log file
+// The message and the error variable will only be logged if the LogLevelSpecific of the logger is set to ErrorLevel,
+// or if the LogLevelSpecific is set to -1 and the LogLevel is less than or equal to ErrorLevel.
 //
-// Returns: _
+// Parameters:
+//
+// message string - The message to write to the log file.
+//
+// err error - The error variable to write to the log file.
+//
+// Returns: None
 func (l *CustomLogger) ErrorWithErr(message string, err error) {
-	l.Println("ERROR: " + message + " " + err.Error())
+	if l.LogLevelSpecific == -1 && l.LogLevel <= ErrorLevel || l.LogLevelSpecific == ErrorLevel {
+		l.Println("ERROR: " + message + " " + err.Error())
+	}
 }
 
-// Fatal writes a fatal level message to the log file
-// TODO: fix this docstring according to new documentation standard
-// Parameters: message string - the message to write to the log file
+// Fatal writes a fatal level message to the log file, including the error variable.
 //
-// Returns: _
+// The message and the error variable will only be logged if the LogLevelSpecific of the logger is set to FatalLevel,
+// or if the LogLevelSpecific is set to -1 and the LogLevel is less than or equal to FatalLevel.
+//
+// Parameters:
+//
+// message string - The message to write to the log file.
+//
+// Returns: None
 func (l *CustomLogger) Fatal(message string) {
-	l.Fatalln("FATAL: " + message)
+	if l.LogLevelSpecific == -1 && l.LogLevel <= FatalLevel || l.LogLevelSpecific == FatalLevel {
+		l.Fatalln("FATAL: " + message)
+	}
 }
 
-// FatalWithErr writes a fatal level message to the log file, including the error variable
-// TODO: fix this docstring according to new documentation standard
-// Parameters: message string - the message to write to the log file
+// FatalWithErr writes a fatal level message to the log file, including the error variable.
 //
-// err error - the error variable to write to the log file
+// The message and the error variable will only be logged if the LogLevelSpecific of the logger is set to FatalLevel,
+// or if the LogLevelSpecific is set to -1 and the LogLevel is less than or equal to FatalLevel.
 //
-// Returns: _
+// Parameters:
+//
+// message string - The message to write to the log file.
+//
+// err error - The error variable to write to the log file.
+//
+// Returns: None
 func (l *CustomLogger) FatalWithErr(message string, err error) {
-	l.Fatalln("FATAL: " + message + " " + err.Error())
+	if l.LogLevelSpecific == -1 && l.LogLevel <= FatalLevel || l.LogLevelSpecific == FatalLevel {
+		l.Fatalln("FATAL: " + message + " " + err.Error())
+	}
 }

--- a/main.go
+++ b/main.go
@@ -20,7 +20,16 @@ import (
 // Returns: None. This function does not return a value as it is the entry point of the application.
 func main() {
 	localization.Init("")
-	logger.Setup()
+	// Set up the logger, passing the log-level you desire (it logs everything equal and lower to the log-level):
+	// 0 - Trace
+	// 1 - Debug
+	// 2 - Info
+	// 3 - Warning
+	// 4 - Error
+	// 5 - Fatal
+	// The second argument is the specific log-level you want to log, giving this a value will only log that level.
+	// If you want to log all levels up to the specified level, pass -1.
+	logger.Setup(0, -1)
 	logger.Log.Info("Starting InfoSec Agent")
 	systray.Run(tray.OnReady, tray.OnQuit)
 }

--- a/reporting-page/main.go
+++ b/reporting-page/main.go
@@ -57,7 +57,7 @@ func (h *FileLoader) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 //
 // Returns: None. This function does not return a value as it is the entry point of the application.
 func main() {
-	logger.Setup()
+	logger.Setup(0, -1)
 	logger.Log.Info("Reporting page starting")
 
 	// Create a new instance of the app and tray struct


### PR DESCRIPTION
You can now specify the log-level and also a log-level filter if you only want an individual log-level. It is separate for the system-tray and the reporting-page (because we have 2 log files).