### PR TITLE
CopyFile fix

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -64,7 +64,7 @@ func CopyFile(src, dst string, mockSource mocking.File, mockDestination mocking.
 		}
 	}(destinationFile)
 
-	_, err = sourceFile.Copy(destinationFile, sourceFile)
+	_, err = sourceFile.Copy(sourceFile, destinationFile)
 	if err != nil {
 		logger.Log.Println("Error copying file:", err)
 		return err


### PR DESCRIPTION
Buffer was missing, now a buffer of 1.1 times the size of the file is allocated for copying files. A dynamic size was chosen as file size can vary from 1kb to 1gb.