### PR TITLE
V24A-483 Change return of CIS registry settings check

### DIFF
--- a/checks/cisregistrysettings/cis_registry_other.go
+++ b/checks/cisregistrysettings/cis_registry_other.go
@@ -11,9 +11,7 @@ import "github.com/InfoSec-Agent/InfoSec-Agent/mocking"
 //
 //   - registryKey (mocking.RegistryKey): The root key from which the registry settings will be checked. Should be HKEY_LOCAL_MACHINE for this function.
 //
-// Returns:
-//
-//   - []bool: A slice of boolean values, where each boolean represents whether a particular registry setting adheres to the CIS Benchmark standards.
+// Returns: None
 func CheckOtherRegistrySettings(registryKey mocking.RegistryKey) {
 	for _, check := range generalRegistryChecks {
 		check(registryKey)

--- a/checks/cisregistrysettings/cis_registry_other.go
+++ b/checks/cisregistrysettings/cis_registry_other.go
@@ -17,7 +17,7 @@ import "github.com/InfoSec-Agent/InfoSec-Agent/mocking"
 func CheckOtherRegistrySettings(registryKey mocking.RegistryKey) []bool {
 	results := make([]bool, 0)
 	for _, check := range generalRegistryChecks {
-		results = append(results, check(registryKey)...)
+		check(registryKey)
 	}
 
 	return results
@@ -26,7 +26,7 @@ func CheckOtherRegistrySettings(registryKey mocking.RegistryKey) []bool {
 // generalRegistryChecks is a collection of registry checks related to different (unrelated) registry keys.
 // Each function in the collection represents a different registry setting check that the application can perform.
 // The registry settings get checked against the CIS Benchmark recommendations.
-var generalRegistryChecks = []func(mocking.RegistryKey) []bool{
+var generalRegistryChecks = []func(mocking.RegistryKey){
 	CheckAutoConnectHotspot,
 	CheckCurrentVersionRegistry,
 	CheckControlLsa,
@@ -39,21 +39,20 @@ var generalRegistryChecks = []func(mocking.RegistryKey) []bool{
 // CheckAutoConnectHotspot is a helper function that checks the registry to determine if the system is configured to automatically connect to hotspots.
 //
 // CIS Benchmark Audit list index: 18.5.23.2.1
-func CheckAutoConnectHotspot(registryKey mocking.RegistryKey) []bool {
+func CheckAutoConnectHotspot(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Microsoft\WcmSvc\wifinetworkmanager\config`
 
 	settings := []string{"AutoConnectAllowedOEM"}
 
 	expectedValues := []interface{}{uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // CheckCurrentVersionRegistry is a helper function that checks the registry to determine if the system is configured with the correct settings for the current version.
 //
 // CIS Benchmark Audit list indices: 2.3.4.1, 2.3.7.8, 2.3.7.9, 18.2.1, 18.4.1, 18.4.10
-func CheckCurrentVersionRegistry(registryKey mocking.RegistryKey) []bool {
-	result := make([]bool, 0)
+func CheckCurrentVersionRegistry(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon`
 
 	settings := []string{
@@ -66,7 +65,7 @@ func CheckCurrentVersionRegistry(registryKey mocking.RegistryKey) []bool {
 
 	expectedValues := []interface{}{uint64(2), []uint64{5, 14}, []uint64{1, 2, 3}, uint64(0), []uint64{0, 5}}
 
-	result = append(result, CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)...)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 
 	registryPath =
 		`SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\GPExtensions\{D76B9641-3288-4f75-942D-087DE603E3EA}`
@@ -75,16 +74,14 @@ func CheckCurrentVersionRegistry(registryKey mocking.RegistryKey) []bool {
 
 	expectedStringValues := []string{"C:\\Program Files\\LAPS\\CSE\\AdmPwd.dll"}
 
-	result = append(result,
-		CheckStringRegistrySettings(registryKey, registryPath, settings, expectedStringValues)...)
-	return result
+	CheckStringRegistrySettings(registryKey, registryPath, settings, expectedStringValues)
 }
 
 // CheckControlLsa is a helper function that checks the registry to determine if the system is configured with the correct settings for Control Lsa.
 //
 // CIS Benchmark Audit list indices: 2.3.1.4, 2.3.2.1-2, 2.3.10.2-5, 2.3.10.10, 2.3.10.12,
 // 2.3.11.1-3, 2.3.11.5, 2.3.11.7, 2.3.11.9-10
-func CheckControlLsa(registryKey mocking.RegistryKey) []bool {
+func CheckControlLsa(registryKey mocking.RegistryKey) {
 	registryPath := `SYSTEM\CurrentControlSet\Control\Lsa`
 
 	settings := []string{"LimitBlankPasswordUse", "SCENoApplyLegacyAuditPolicy", "CrashOnAuditFail",
@@ -94,66 +91,62 @@ func CheckControlLsa(registryKey mocking.RegistryKey) []bool {
 	expectedValues := []interface{}{uint64(1), uint64(1), uint64(0), uint64(1), uint64(1), uint64(1), uint64(0),
 		uint64(1), uint64(0), uint64(1), uint64(1), uint64(5)}
 
-	results := make([]bool, 0)
-	results = append(results, CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)...)
-	results = append(results, checkLsaMSV(registryKey)...)
-	results = append(results, checkLsapku2u(registryKey)...)
-	return results
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	checkLsaMSV(registryKey)
+	checkLsapku2u(registryKey)
 }
 
 // checkLsaMSV is a helper function that checks the registry to determine if the system is configured with the correct settings for Lsa MSV.
 //
 // CIS Benchmark Audit list indices: 2.3.11.2, 2.3.11.9-10
-func checkLsaMSV(registryKey mocking.RegistryKey) []bool {
+func checkLsaMSV(registryKey mocking.RegistryKey) {
 	registryPath := `SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0`
 
 	settings := []string{"AllowNullSessionFallback", "NTLMMinClientSec", "NTLMMinServerSec"}
 
 	expectedValues := []interface{}{uint64(0), uint64(537395200), uint64(537395200)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // checkLsapku2u is a helper function that checks the registry to determine if the system is configured with the correct settings for Lsa pku2u.
 //
 // CIS Benchmark Audit list index: 2.3.11.3
-func checkLsapku2u(registryKey mocking.RegistryKey) []bool {
+func checkLsapku2u(registryKey mocking.RegistryKey) {
 	registryPath := `SYSTEM\CurrentControlSet\Control\Lsa\pku2u`
 
 	settings := []string{"AllowOnlineID"}
 
 	expectedValues := []interface{}{uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // CheckControlSAM is a helper function that checks the registry to determine if the system is configured with the correct settings for Control SAM.
 //
 // CIS Benchmark Audit list index: 1.1.6
-func CheckControlSAM(registryKey mocking.RegistryKey) []bool {
+func CheckControlSAM(registryKey mocking.RegistryKey) {
 	registryPath := `SYSTEM\CurrentControlSet\Control\SAM`
 
 	settings := []string{"RelaxMinimumPasswordLengthLimits"}
 
 	expectedValues := []interface{}{uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // CheckSecurePipeServers is a helper function that checks the registry to determine if the system is configured with the correct settings for secure pipe servers.
 //
 // CIS Benchmark Audit list indices: 2.3.10.7-8
-func CheckSecurePipeServers(registryKey mocking.RegistryKey) []bool {
-	results := make([]bool, 0)
-	results = append(results, securePipeServersExactPaths(registryKey)...)
-	results = append(results, securePipeServersPaths(registryKey)...)
-	return results
+func CheckSecurePipeServers(registryKey mocking.RegistryKey) {
+	securePipeServersExactPaths(registryKey)
+	securePipeServersPaths(registryKey)
 }
 
 // securePipeServersExactPaths is a helper function that checks the registry to determine if the system is configured with the correct settings for secure pipe servers exact paths.
 //
 // CIS Benchmark Audit list index: 2.3.10.7
-func securePipeServersExactPaths(registryKey mocking.RegistryKey) []bool {
+func securePipeServersExactPaths(registryKey mocking.RegistryKey) {
 	registryPath := `SYSTEM\CurrentControlSet\Control\SecurePipeServers\Winreg\AllowedExactPaths`
 
 	settings := []string{"Machine"}
@@ -162,13 +155,13 @@ func securePipeServersExactPaths(registryKey mocking.RegistryKey) []bool {
 		"System\\CurrentControlSet\\Control\\ProductOptionsSystem\\CurrentControlSet\\Control\\" +
 		"Server ApplicationsSoftware\\Microsoft\\Windows NT\\CurrentVersion"}
 
-	return CheckStringRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckStringRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // securePipeServersPaths is a helper function that checks the registry to determine if the system is configured with the correct settings for secure pipe servers paths.
 //
 // CIS Benchmark Audit list index: 2.3.10.8
-func securePipeServersPaths(registryKey mocking.RegistryKey) []bool {
+func securePipeServersPaths(registryKey mocking.RegistryKey) {
 	registryPath := `SYSTEM\CurrentControlSet\Control\SecurePipeServers\Winreg\AllowedPaths`
 
 	settings := []string{"Machine"}
@@ -181,47 +174,45 @@ func securePipeServersPaths(registryKey mocking.RegistryKey) []bool {
 		"\\Control\\Terminal Server\\DefaultUserConfigurationSoftware\\Microsoft\\Windows NT\\CurrentVersion" +
 		"\\PerflibSystem\\CurrentControlSet\\Services\\Sysmonlog"}
 
-	return CheckStringRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckStringRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // CheckWDigest is a helper function that checks the registry to determine if the system is configured with the correct settings for WDigest.
 //
 // CIS Benchmark Audit list index: 18.3.7
-func CheckWDigest(registryKey mocking.RegistryKey) []bool {
+func CheckWDigest(registryKey mocking.RegistryKey) {
 	registryPath := `SYSTEM\CurrentControlSet\Control\SecurityProviders\WDigest`
 
 	settings := []string{"UseLogonCredential"}
 
 	expectedValues := []interface{}{uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // CheckSessionManager is a helper function that checks the registry to determine if the system is configured with the correct settings for the session manager.
 //
 // CIS Benchmark Audit list indices: 2.3.15.1-2, 18.3.4, 18.4.9
-func CheckSessionManager(registryKey mocking.RegistryKey) []bool {
+func CheckSessionManager(registryKey mocking.RegistryKey) {
 	registryPath := `SYSTEM\CurrentControlSet\Control\Session Manager`
 
 	settings := []string{"ProtectionMode", "SafeDllSearchMode"}
 
 	expectedValues := []interface{}{uint64(1), uint64(1)}
 
-	results := make([]bool, 0)
-	results = append(results, CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)...)
-	results = append(results, sessionManagerKernel(registryKey)...)
-	return results
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	sessionManagerKernel(registryKey)
 }
 
 // sessionManagerKernel is a helper function that checks the registry to determine if the system is configured with the correct settings for the session manager kernel.
 //
 // CIS Benchmark Audit list indices: 2.3.15.1, 18.3.4
-func sessionManagerKernel(registryKey mocking.RegistryKey) []bool {
+func sessionManagerKernel(registryKey mocking.RegistryKey) {
 	registryPath := `SYSTEM\CurrentControlSet\Control\Session Manager\Kernel`
 
 	settings := []string{"ObCaseInsensitive", "DisableExceptionChainValidation"}
 
 	expectedValues := []interface{}{uint64(1), uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }

--- a/checks/cisregistrysettings/cis_registry_other.go
+++ b/checks/cisregistrysettings/cis_registry_other.go
@@ -14,13 +14,10 @@ import "github.com/InfoSec-Agent/InfoSec-Agent/mocking"
 // Returns:
 //
 //   - []bool: A slice of boolean values, where each boolean represents whether a particular registry setting adheres to the CIS Benchmark standards.
-func CheckOtherRegistrySettings(registryKey mocking.RegistryKey) []bool {
-	results := make([]bool, 0)
+func CheckOtherRegistrySettings(registryKey mocking.RegistryKey) {
 	for _, check := range generalRegistryChecks {
 		check(registryKey)
 	}
-
-	return results
 }
 
 // generalRegistryChecks is a collection of registry checks related to different (unrelated) registry keys.

--- a/checks/cisregistrysettings/cis_registry_policies.go
+++ b/checks/cisregistrysettings/cis_registry_policies.go
@@ -18,7 +18,7 @@ func CheckPoliciesHKU(registryKey mocking.RegistryKey) []bool {
 	results := make([]bool, 0)
 
 	for _, check := range policyChecksHKU {
-		results = append(results, check(registryKey)...)
+		check(registryKey)
 	}
 
 	return results
@@ -27,7 +27,7 @@ func CheckPoliciesHKU(registryKey mocking.RegistryKey) []bool {
 // policyChecksHKU is a collection of registry checks related to different policies.
 // Each function in the collection represents a different policy check that the application can perform.
 // The registry settings get checked against the CIS Benchmark recommendations.
-var policyChecksHKU = []func(mocking.RegistryKey) []bool{
+var policyChecksHKU = []func(mocking.RegistryKey){
 	policiesAttachments,
 	policiesExplorerHKU,
 	policiesCloudContentHKU,
@@ -39,77 +39,77 @@ var policyChecksHKU = []func(mocking.RegistryKey) []bool{
 // policiesAttachments is a helper function that checks the registry to determine if the system is configured with the correct settings for attachments.
 //
 // CIS Benchmark Audit list indices: 19.7.4.1-2
-func policiesAttachments(registryKey mocking.RegistryKey) []bool {
+func policiesAttachments(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Attachments`
 
 	settings := []string{"SaveZoneInformation", "ScanWithAntiVirus"}
 
 	expectedValues := []interface{}{uint64(2), uint64(3)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesExplorer is a helper function that checks the registry to determine if the system is configured with the correct settings for the Explorer policies.
 //
 // CIS Benchmark Audit list index: 19.7.28.1
-func policiesExplorerHKU(registryKey mocking.RegistryKey) []bool {
+func policiesExplorerHKU(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer`
 
 	settings := []string{"NoInplaceSharing"}
 
 	expectedValues := []interface{}{uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesCloudContentHKU is a helper function that checks the registry to determine if the system is configured with the correct settings for cloud content.
 //
 // CIS Benchmark Audit list indices: 19.7.8.1-2, 19.7.8.5
-func policiesCloudContentHKU(registryKey mocking.RegistryKey) []bool {
+func policiesCloudContentHKU(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\CloudContent`
 
 	settings := []string{"ConfigureWindowsSpotlight", "DisableThirdPartySuggestions", "DisableSpotlightCollectionOnDesktop"}
 
 	expectedValues := []interface{}{uint64(2), uint64(1), uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesControlPanelDesktop is a helper function that checks the registry to determine if the system is configured with the correct settings for the Control Panel Desktop.
 //
 // CIS Benchmark Audit list indices: 19.1.3.1-3
-func policiesControlPanelDesktop(registryKey mocking.RegistryKey) []bool {
+func policiesControlPanelDesktop(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\Control Panel\Desktop`
 
 	settings := []string{"ScreenSaveActive", "ScreenSaverIsSecure", "ScreenSaveTimeOut"}
 
 	expectedValues := []interface{}{uint64(1), uint64(1), []uint64{0, 900}}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesPushNotifications is a helper function that checks the registry to determine if the system is configured with the correct settings for push notifications.
 //
 // CIS Benchmark Audit list index: 19.5.1.1
-func policiesPushNotifications(registryKey mocking.RegistryKey) []bool {
+func policiesPushNotifications(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\PushNotifications`
 
 	settings := []string{"NoToastApplicationNotificationOnLockScreen"}
 
 	expectedValues := []interface{}{uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesInstallerHKU is a helper function that checks the registry to determine if the system is configured with the correct settings for the Installer.
 //
 // CIS Benchmark Audit list index: 19.7.43.1
-func policiesInstallerHKU(registryKey mocking.RegistryKey) []bool {
+func policiesInstallerHKU(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\Installer`
 
 	settings := []string{"AlwaysInstallElevated"}
 
 	expectedValues := []interface{}{uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }

--- a/checks/cisregistrysettings/cis_registry_policies.go
+++ b/checks/cisregistrysettings/cis_registry_policies.go
@@ -16,7 +16,6 @@ func CheckPoliciesHKU(registryKey mocking.RegistryKey) {
 	for _, check := range policyChecksHKU {
 		check(registryKey)
 	}
-
 }
 
 // policyChecksHKU is a collection of registry checks related to different policies.

--- a/checks/cisregistrysettings/cis_registry_policies.go
+++ b/checks/cisregistrysettings/cis_registry_policies.go
@@ -11,17 +11,12 @@ import "github.com/InfoSec-Agent/InfoSec-Agent/mocking"
 //
 //   - registryKey (mocking.RegistryKey): The root key from which the registry settings will be checked. Should be HKEY_USERS for this function.
 //
-// Returns:
-//
-//   - []bool: A slice of boolean values, where each boolean represents whether a particular registry setting adheres to the CIS Benchmark standards.
-func CheckPoliciesHKU(registryKey mocking.RegistryKey) []bool {
-	results := make([]bool, 0)
-
+// Returns: None
+func CheckPoliciesHKU(registryKey mocking.RegistryKey) {
 	for _, check := range policyChecksHKU {
 		check(registryKey)
 	}
 
-	return results
 }
 
 // policyChecksHKU is a collection of registry checks related to different policies.

--- a/checks/cisregistrysettings/cis_registry_policies_HKLM.go
+++ b/checks/cisregistrysettings/cis_registry_policies_HKLM.go
@@ -17,7 +17,7 @@ import "github.com/InfoSec-Agent/InfoSec-Agent/mocking"
 func CheckPoliciesHKLM(registryKey mocking.RegistryKey) []bool {
 	results := make([]bool, 0)
 	for _, check := range policyChecksHKLM {
-		results = append(results, check(registryKey)...)
+		check(registryKey)
 	}
 
 	return results
@@ -26,7 +26,7 @@ func CheckPoliciesHKLM(registryKey mocking.RegistryKey) []bool {
 // policyChecksHKLM is a collection of registry checks related to different policies.
 // Each function in the collection represents a different policy check that the application can perform.
 // The registry settings get checked against the CIS Benchmark recommendations.
-var policyChecksHKLM = []func(mocking.RegistryKey) []bool{
+var policyChecksHKLM = []func(mocking.RegistryKey){
 	policiesCredui,
 	policiesExplorerHKLM,
 	policiesSystem,
@@ -79,20 +79,20 @@ var policyChecksHKLM = []func(mocking.RegistryKey) []bool{
 // policiesCredui is a helper function that checks the registry to determine if the system is configured to enumerate administrator accounts.
 //
 // CIS Benchmark Audit list index: 18.9.16.2
-func policiesCredui(registryKey mocking.RegistryKey) []bool {
+func policiesCredui(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Microsoft\Windows\Currentversion\Policies\Credui`
 
 	settings := []string{"EnumerateAdministrators"}
 
 	expectedValues := []interface{}{uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesExplorerHKLM is a helper function that checks the registry to determine if the system is configured with the correct settings for Explorer policies.
 //
 // CIS Benchmark Audit list indices: 18.8.22.1.6, 18.9.8.2, 18.9.8.3, 18.9.31.4
-func policiesExplorerHKLM(registryKey mocking.RegistryKey) []bool {
+func policiesExplorerHKLM(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer`
 
 	settings := []string{
@@ -104,14 +104,13 @@ func policiesExplorerHKLM(registryKey mocking.RegistryKey) []bool {
 
 	expectedValues := []interface{}{uint64(1), uint64(1), uint64(255), uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesSystem is a helper function that checks the registry to determine if the system is configured with the correct settings for system policies.
 //
 // CIS Benchmark Audit list indices: 2.3.1.2, 2.3.7.1-3, 2.3.11.4, 2.3.17.1-8, 18.3.1, 18.8.3.1, 18.8.4.1, 18.9.6.1, 18.9.91.1
-func policiesSystem(registryKey mocking.RegistryKey) []bool {
-	result := make([]bool, 0)
+func policiesSystem(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System`
 
 	settings := []string{
@@ -134,7 +133,7 @@ func policiesSystem(registryKey mocking.RegistryKey) []bool {
 	expectedValues := []interface{}{uint64(3), uint64(0), uint64(1), []uint64{0, 900}, uint64(1), uint64(2), uint64(0),
 		uint64(1), uint64(1), uint64(1), uint64(1), uint64(1), uint64(0), uint64(1), uint64(1)}
 
-	result = append(result, CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)...)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 
 	subKeys := []string{
 		`SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\Kerberos\Parameters`,
@@ -153,17 +152,16 @@ func policiesSystem(registryKey mocking.RegistryKey) []bool {
 	for i, subKey := range subKeys {
 		func() {
 			registryPath = subKey
-			result = append(result, CheckIntegerRegistrySettings(
-				registryKey, registryPath, []string{subKeysSettings[i]}, []interface{}{subKeysExpected[i]})...)
+			CheckIntegerRegistrySettings(
+				registryKey, registryPath, []string{subKeysSettings[i]}, []interface{}{subKeysExpected[i]})
 		}()
 	}
-	return result
 }
 
 // policiesAdmPwd is a helper function that checks the registry to determine if the system is configured with the correct settings for the administrator password.
 //
 // CIS Benchmark Audit list indices: 18.2.2-6
-func policiesAdmPwd(registryKey mocking.RegistryKey) []bool {
+func policiesAdmPwd(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft Services\AdmPwd`
 
 	settings := []string{
@@ -176,92 +174,91 @@ func policiesAdmPwd(registryKey mocking.RegistryKey) []bool {
 
 	expectedValues := []interface{}{uint64(1), uint64(1), uint64(4), []uint64{15, ^uint64(0)}, []uint64{0, 30}}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesFacialFeatures is a helper function that checks the registry to determine if the system is configured with the correct settings for enhanced anti-spoofing.
 //
 // CIS Benchmark Audit list index: 18.9.10.1.1
-func policiesFacialFeatures(registryKey mocking.RegistryKey) []bool {
+func policiesFacialFeatures(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Biometrics\FacialFeatures`
 
 	settings := []string{"EnhancedAntiSpoofing"}
 
 	expectedValues := []interface{}{uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesDsh is a helper function that checks the registry to determine if the system is configured to allow widgets.
 //
 // CIS Benchmark Audit list index: 18.9.81.1
-func policiesDsh(registryKey mocking.RegistryKey) []bool {
+func policiesDsh(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Dsh`
 
 	settings := []string{"AllowNewsAndInterests"}
 
 	expectedValues := []interface{}{uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesInputPersonalization is a helper function that checks the registry to determine if the system is configured to allow online speech recognition services.
 //
 // CIS Benchmark Audit list index: 18.1.2.2
-func policiesInputPersonalization(registryKey mocking.RegistryKey) []bool {
+func policiesInputPersonalization(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\InputPersonalization`
 
 	settings := []string{"AllowInputPersonalization"}
 
 	expectedValues := []interface{}{uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesIEFeeds is a helper function that checks the registry to determine if the system is configured to download enclosures.
 //
 // CIS Benchmark Audit list index: 18.9.66.1
-func policiesIEFeeds(registryKey mocking.RegistryKey) []bool {
+func policiesIEFeeds(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Internet Explorer\Feeds`
 
 	settings := []string{"DisableEnclosureDownload"}
 
 	expectedValues := []interface{}{uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesMicrosoftAccount is a helper function that checks the registry to determine if the system is configured to block consumer user authentication.
 //
 // CIS Benchmark Audit list index: 18.9.46.1
-func policiesMicrosoftAccount(registryKey mocking.RegistryKey) []bool {
+func policiesMicrosoftAccount(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\MicrosoftAccount`
 
 	settings := []string{"DisableUserAuth"}
 
 	expectedValues := []interface{}{uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesPhishingFilter is a helper function that checks the registry to determine if the system is configured with the correct settings for the phishing filter.
 //
 // CIS Benchmark Audit list indices: 18.9.85.2.1-2
-func policiesPhishingFilter(registryKey mocking.RegistryKey) []bool {
+func policiesPhishingFilter(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\MicrosoftEdge\PhishingFilter`
 
 	settings := []string{"EnabledV9", "PreventOverride"}
 
 	expectedValues := []interface{}{uint64(1), uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesPowerSettings is a helper function that checks the registry to determine if the system is configured with the correct power settings.
 //
 // CIS Benchmark Audit list indices: 18.8.34.6.1-2, 18.8.34.6.5-6
-func policiesPowerSettings(registryKey mocking.RegistryKey) []bool {
-	result := make([]bool, 0)
+func policiesPowerSettings(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Power\PowerSettings\f15576e8-98b7-4186-b944-eafa664402d9`
 
 	settings := []string{
@@ -271,21 +268,19 @@ func policiesPowerSettings(registryKey mocking.RegistryKey) []bool {
 
 	expectedValues := []interface{}{uint64(0), uint64(0)}
 
-	result = append(result, CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)...)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 
 	registryPath = `SOFTWARE\Policies\Microsoft\Power\PowerSettings\0e796bdb-100d-47d6-a2d5-f7d2daa51f51`
 
 	expectedValues = []interface{}{uint64(1), uint64(1)}
 
-	result = append(result, CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)...)
-	return result
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesWindowsDefender is a helper function that checks the registry to determine if Windows Defender is configured with the correct settings.
 //
 // CIS Benchmark Audit list indices: 18.9.47.15-16
-func policiesWindowsDefender(registryKey mocking.RegistryKey) []bool {
-	results := make([]bool, 0)
+func policiesWindowsDefender(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows Defender`
 
 	settings := []string{
@@ -295,55 +290,53 @@ func policiesWindowsDefender(registryKey mocking.RegistryKey) []bool {
 
 	expectedValues := []interface{}{uint64(1), uint64(0)}
 
-	results = append(results, CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)...)
-	results = append(results, checkWindowsDefenderScan(registryKey)...)
-	results = append(results, checkWindowsDefenderRealTime(registryKey)...)
-	results = append(results, checkWindowsDefenderASR(registryKey)...)
-	results = append(results, checkWindowsDefenderSpyNet(registryKey)...)
-	results = append(results, checkWindowsDefenderNetworkProtection(registryKey)...)
-	results = append(results, checkWindowsDefenderAppBrowserProtection(registryKey)...)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	checkWindowsDefenderScan(registryKey)
+	checkWindowsDefenderRealTime(registryKey)
+	checkWindowsDefenderASR(registryKey)
+	checkWindowsDefenderSpyNet(registryKey)
+	checkWindowsDefenderNetworkProtection(registryKey)
+	checkWindowsDefenderAppBrowserProtection(registryKey)
 
-	return results
 }
 
 // checkWindowsDefenderScan is a helper function that checks the registry to determine if Windows Defender is configured with the correct scan settings.
 //
 // CIS Benchmark Audit list indices: 18.9.47.12.1-2
-func checkWindowsDefenderScan(registryKey mocking.RegistryKey) []bool {
+func checkWindowsDefenderScan(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows Defender\Scan`
 
 	settings := []string{"DisableRemovableDriveScanning", "DisableEmailScanning"}
 
 	expectedValues := []interface{}{uint64(0), uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // checkWindowsDefenderRealTime is a helper function that checks the registry to determine if Windows Defender is configured with the correct real-time protection settings.
 //
 // CIS Benchmark Audit list indices: 18.9.47.9.1-4
-func checkWindowsDefenderRealTime(registryKey mocking.RegistryKey) []bool {
+func checkWindowsDefenderRealTime(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows Defender\Real-Time Protection`
 
 	settings := []string{"DisableIOAVProtection", "DisableRealtimeMonitoring", "DisableBehaviorMonitoring", "DisableScriptScanning"}
 
 	expectedValues := []interface{}{uint64(0), uint64(0), uint64(0), uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // checkWindowsDefenderASR is a helper function that checks the registry to determine if Windows Defender is configured with the correct ASR settings.
 //
 // CIS Benchmark Audit list indices: 18.9.47.5.1.1-2
-func checkWindowsDefenderASR(registryKey mocking.RegistryKey) []bool {
-	results := make([]bool, 0)
+func checkWindowsDefenderASR(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR`
 
 	settings := []string{"ExploitGuard_ASR_Rules"}
 
 	expectedValues := []interface{}{uint64(1)}
 
-	results = append(results, CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)...)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 
 	registryPath = `SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules`
 
@@ -363,75 +356,72 @@ func checkWindowsDefenderASR(registryKey mocking.RegistryKey) []bool {
 	expectedValues = []interface{}{uint64(1), uint64(1), uint64(1), uint64(1), uint64(1), uint64(1), uint64(1),
 		uint64(1), uint64(1), uint64(1), uint64(1)}
 
-	results = append(results, CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)...)
-	return results
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // checkWindowsDefenderSpyNet is a helper function that checks the registry to determine if Windows Defender is configured with the correct SpyNet settings.
 //
 // CIS Benchmark Audit list index: 18.9.47.4.1
-func checkWindowsDefenderSpyNet(registryKey mocking.RegistryKey) []bool {
+func checkWindowsDefenderSpyNet(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows Defender\Spynet`
 
 	settings := []string{"LocalSettingOverrideSpynetReporting"}
 
 	expectedValues := []interface{}{uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // checkWindowsDefenderAppBrowserProtection is a helper function that checks the registry to determine if Windows Defender is configured with the correct app and browser protection settings.
 //
 // CIS Benchmark Audit list index: 18.9.105.2.1
-func checkWindowsDefenderAppBrowserProtection(registryKey mocking.RegistryKey) []bool {
+func checkWindowsDefenderAppBrowserProtection(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows Defender Security Center\App and Browser protection`
 
 	settings := []string{"DisallowExploitProtectionOverride"}
 
 	expectedValues := []interface{}{uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // checkWindowsDefenderNetworkProtection is a helper function that checks the registry to determine if Windows Defender is configured with the correct network protection settings.
 //
 // CIS Benchmark Audit list index: 18.9.47.5.3.1
-func checkWindowsDefenderNetworkProtection(registryKey mocking.RegistryKey) []bool {
+func checkWindowsDefenderNetworkProtection(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\Network Protection`
 
 	settings := []string{"EnableNetworkProtection"}
 
 	expectedValues := []interface{}{uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesDNSClient is a helper function that checks the registry to determine if the system is configured with the correct settings for the DNS client.
 //
 // CIS Benchmark Audit list indices: 18.5.4.2
-func policiesDNSClient(registryKey mocking.RegistryKey) []bool {
+func policiesDNSClient(registryKey mocking.RegistryKey) {
 	registryPath := DNSClientRegistryPath
 
 	settings := []string{"EnableMulticast"}
 
 	expectedValues := []interface{}{uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesPrinters is a helper function that checks the registry to determine if the system is configured with the correct settings for printers.
 //
 // CIS Benchmark Audit list indices: 18.3.5, 18.6.1-3, 18.8.22.1.2
-func policiesPrinters(registryKey mocking.RegistryKey) []bool {
+func policiesPrinters(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows NT\Printers`
-
-	results := make([]bool, 0)
 
 	settings := []string{"RegisterSpoolerRemoteRpcEndPoint", "DisableWebPnPDownload"}
 
 	expectedValues := []interface{}{uint64(2), uint64(1)}
 
-	results = append(results, CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)...)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 
 	registryPath = `SOFTWARE\Policies\Microsoft\Windows NT\Printers\PointAndPrint`
 
@@ -439,27 +429,26 @@ func policiesPrinters(registryKey mocking.RegistryKey) []bool {
 
 	expectedValues = []interface{}{uint64(1), uint64(0), uint64(0)}
 
-	results = append(results, CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)...)
-	return results
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesRPC is a helper function that checks the registry to determine if the system is configured with the correct settings for RPC.
 //
 // CIS Benchmark Audit list indices: 18.8.37.1-2
-func policiesRPC(registryKey mocking.RegistryKey) []bool {
+func policiesRPC(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows NT\Rpc`
 
 	settings := []string{"EnableAuthEpResolution", "RestrictRemoteClients"}
 
 	expectedValues := []interface{}{uint64(1), uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesTerminalServices is a helper function that checks the registry to determine if the system is configured with the correct settings for terminal services.
 //
 // CIS Benchmark Audit list indices: 18.8.36.1-2, 18.9.65.2.2, 18.9.65.3.3.3, 18.9.65.3.9.1-5, 18.9.65.3.11.1
-func policiesTerminalServices(registryKey mocking.RegistryKey) []bool {
+func policiesTerminalServices(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services`
 
 	settings := []string{"fAllowUnsolicited", "fAllowToGetHelp", "DisablePasswordSaving", "fDisableCdm",
@@ -469,91 +458,91 @@ func policiesTerminalServices(registryKey mocking.RegistryKey) []bool {
 	expectedValues := []interface{}{uint64(0), uint64(0), uint64(1), uint64(1), uint64(1), uint64(1), uint64(2),
 		uint64(1), uint64(3), uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesAppPrivacy is a helper function that checks the registry to determine if the system is configured with the correct settings for app privacy.
 //
 // CIS Benchmark Audit list index: 18.9.5.1
-func policiesAppPrivacy(registryKey mocking.RegistryKey) []bool {
+func policiesAppPrivacy(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\AppPrivacy`
 
 	settings := []string{"LetAppsActivateWithVoiceAboveLock"}
 
 	expectedValues := []interface{}{uint64(2)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesAppx is a helper function that checks the registry to determine if the system is configured with the correct settings for Appx.
 //
 // CIS Benchmark Audit list index: 18.9.4.2
-func policiesAppx(registryKey mocking.RegistryKey) []bool {
+func policiesAppx(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\Appx`
 
 	settings := []string{"BlockNonAdminUserInstall"}
 
 	expectedValues := []interface{}{uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesCloudContentHKLM is a helper function that checks the registry to determine if the system is configured with the correct settings for cloud content.
 //
 // CIS Benchmark Audit list indices: 18.9.14.1, 18.9.14.3
-func policiesCloudContentHKLM(registryKey mocking.RegistryKey) []bool {
+func policiesCloudContentHKLM(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\CloudContent`
 
 	settings := []string{"DisableConsumerAccountStateContent", "DisableWindowsConsumerFeatures"}
 
 	expectedValues := []interface{}{uint64(1), uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesConnect is a helper function that checks the registry to determine if the system is configured with the correct settings for Connect.
 //
 // CIS Benchmark Audit list index: 18.9.15.1
-func policiesConnect(registryKey mocking.RegistryKey) []bool {
+func policiesConnect(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\Connect`
 
 	settings := []string{"RequirePinForPairing"}
 
 	expectedValues := []interface{}{[]uint64{1, 2}}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesCredentialsDelegation is a helper function that checks the registry to determine if the system is configured with the correct settings for credentials delegation.
 //
 // CIS Benchmark Audit list index: 18.8.4.2
-func policiesCredentialsDelegation(registryKey mocking.RegistryKey) []bool {
+func policiesCredentialsDelegation(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\CredentialsDelegation`
 
 	settings := []string{"AllowProtectedCreds"}
 
 	expectedValues := []interface{}{uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesGeneralCredui is a helper function that checks the registry to determine if the system is configured with the correct settings for Credui.
 //
 // CIS Benchmark Audit list index: 18.9.16.1
-func policiesGeneralCredui(registryKey mocking.RegistryKey) []bool {
+func policiesGeneralCredui(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\Credui`
 
 	settings := []string{"DisablePasswordReveal"}
 
 	expectedValues := []interface{}{uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesDataCollection is a helper function that checks the registry to determine if the system is configured with the correct settings for data collection.
 //
 // CIS Benchmark Audit list indices: 18.9.17.1, 18.9.17.3-7
-func policiesDataCollection(registryKey mocking.RegistryKey) []bool {
+func policiesDataCollection(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\DataCollection`
 
 	settings := []string{"AllowTelemetry", "DisableOneSettingsDownloads", "DoNotShowFeedbackNotifications",
@@ -561,206 +550,200 @@ func policiesDataCollection(registryKey mocking.RegistryKey) []bool {
 
 	expectedValues := []interface{}{[]uint64{0, 1}, uint64(1), uint64(1), uint64(1), uint64(1), uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesDeliveryOptimization is a helper function that checks the registry to determine if the system is configured with the correct settings for delivery optimization.
 //
 // CIS Benchmark Audit list index: 18.9.18.1
-func policiesDeliveryOptimization(registryKey mocking.RegistryKey) []bool {
+func policiesDeliveryOptimization(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\DeliveryOptimization`
 
 	settings := []string{"DODownloadMode"}
 
 	expectedValues := []interface{}{[]uint64{0, 1, 2, 99, 100}}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesDeviceMetadata is a helper function that checks the registry to determine if the system is configured with the correct settings for device metadata.
 //
 // CIS Benchmark Audit list index: 18.8.7.2
-func policiesDeviceMetadata(registryKey mocking.RegistryKey) []bool {
+func policiesDeviceMetadata(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\Device Metadata`
 
 	settings := []string{"PreventDeviceMetadataFromNetwork"}
 
 	expectedValues := []interface{}{uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesEventLog is a helper function that checks the registry to determine if the system is configured with the correct settings for the event log.
 //
 // CIS Benchmark Audit list indices: 18.9.27.1.1-2
-func policiesEventLog(registryKey mocking.RegistryKey) []bool {
+func policiesEventLog(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\EventLog\Application`
 
 	settings := []string{"Retention", "MaxSize"}
 
 	expectedValues := []interface{}{uint64(0), []uint64{32768, ^uint64(0)}}
 
-	results := make([]bool, 0)
-	results = append(results, CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)...)
-	results = append(results, checkEventLogSecurity(registryKey)...)
-	results = append(results, checkEventLogSetup(registryKey)...)
-	results = append(results, checkEventLogSystem(registryKey)...)
-	return results
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	checkEventLogSecurity(registryKey)
+	checkEventLogSetup(registryKey)
+	checkEventLogSystem(registryKey)
 }
 
 // checkEventLogSecurity is a helper function that checks the registry to determine if the system is configured with the correct settings for the security event log.
 //
 // CIS Benchmark Audit list indices: 18.9.27.2.1-2
-func checkEventLogSecurity(registryKey mocking.RegistryKey) []bool {
+func checkEventLogSecurity(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\EventLog\Security`
 
 	settings := []string{"Retention", "MaxSize"}
 
 	expectedValues := []interface{}{uint64(0), []uint64{196608, ^uint64(0)}}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // checkEventLogSetup is a helper function that checks the registry to determine if the system is configured with the correct settings for the setup event log.
 //
 // CIS Benchmark Audit list indices: 18.9.27.3.1-2
-func checkEventLogSetup(registryKey mocking.RegistryKey) []bool {
+func checkEventLogSetup(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\Eventlog\Setup`
 
 	settings := []string{"Retention", "MaxSize"}
 
 	expectedValues := []interface{}{uint64(0), []uint64{32768, ^uint64(0)}}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // checkEventLogSystem is a helper function that checks the registry to determine if the system is configured with the correct settings for the system event log.
 //
 // CIS Benchmark Audit list indices: 18.9.27.4.1-2
-func checkEventLogSystem(registryKey mocking.RegistryKey) []bool {
+func checkEventLogSystem(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\EventLog\System`
 
 	settings := []string{"Retention", "MaxSize"}
 
 	expectedValues := []interface{}{uint64(0), []uint64{32768, ^uint64(0)}}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesWindowsExplorer is a helper function that checks the registry to determine if the system is configured with the correct settings for Windows Explorer.
 //
 // CIS Benchmark Audit list indices: 18.9.8.1, 18.9.31.2-3,
-func policiesWindowsExplorer(registryKey mocking.RegistryKey) []bool {
+func policiesWindowsExplorer(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\Explorer`
 
 	settings := []string{"NoAutoplayfornonVolume", "NoDataExecutionPrevention", "NoHeapTerminationOnCorruption"}
 
 	expectedValues := []interface{}{uint64(1), uint64(0), uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesGameDVR is a helper function that checks the registry to determine if the system is configured with the correct settings for GameDVR.
 //
 // CIS Benchmark Audit list index: 18.9.87.1
-func policiesGameDVR(registryKey mocking.RegistryKey) []bool {
+func policiesGameDVR(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\GameDVR`
 
 	settings := []string{"AllowGameDVR"}
 
 	expectedValues := []interface{}{uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesGroupPolicy is a helper function that checks the registry to determine if the system is configured with the correct settings for Group Policy.
 //
 // CIS Benchmark Audit list indices: 18.8.21.2-3
-func policiesGroupPolicy(registryKey mocking.RegistryKey) []bool {
+func policiesGroupPolicy(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\Group Policy\{35378EAC-683F-11D2-A89A-00C04FBBCFA2}`
 
 	settings := []string{"NoBackgroundPolicy", "NoGPOListChanges"}
 
 	expectedValues := []interface{}{uint64(0), uint64(0)}
 
-	results := make([]bool, 0)
-	results = append(results, CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)...)
-	results = append(results, checkWcmSvcGroupPolicy(registryKey)...)
-	return results
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	checkWcmSvcGroupPolicy(registryKey)
 }
 
 // checkWcmSvcGroupPolicy is a helper function that checks the registry to determine if the system is configured with the correct settings for WcmSvc group policy.
 //
 // CIS Benchmark Audit list indices: 18.5.21.1-2
-func checkWcmSvcGroupPolicy(registryKey mocking.RegistryKey) []bool {
+func checkWcmSvcGroupPolicy(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\WcmSvc\GroupPolicy`
 
 	settings := []string{"fMinimizeConnections", "fBlockNonDomain"}
 
 	expectedValues := []interface{}{uint64(3), uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesHomeGroup is a helper function that checks the registry to determine if the system is configured with the correct settings for HomeGroup.
 //
 // CIS Benchmark Audit list index: 18.9.36.1
-func policiesHomeGroup(registryKey mocking.RegistryKey) []bool {
+func policiesHomeGroup(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\HomeGroup`
 
 	settings := []string{"DisableHomeGroup"}
 
 	expectedValues := []interface{}{uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesInstallerHKLM is a helper function that checks the registry to determine if the system is configured with the correct settings for the installer.
 //
 // CIS Benchmark Audit list indices: 18.9.90.1-2
-func policiesInstallerHKLM(registryKey mocking.RegistryKey) []bool {
+func policiesInstallerHKLM(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\Installer`
 
 	settings := []string{"EnableUserControl", "AlwaysInstallElevated"}
 
 	expectedValues := []interface{}{uint64(0), uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesLanman is a helper function that checks the registry to determine if the system is configured with the correct settings for Lanman.
 //
 // CIS Benchmark Audit list index: 18.5.8.1
-func policiesLanman(registryKey mocking.RegistryKey) []bool {
+func policiesLanman(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\LanmanWorkstation`
 
 	settings := []string{"AllowInsecureGuestAuth"}
 
 	expectedValues := []interface{}{uint64(0)}
-	results := make([]bool, 0)
-	results = append(results, CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)...)
-	results = append(results, checkLanmanParameters(registryKey)...)
-	results = append(results, checkLanmanServerParameters(registryKey)...)
-	return results
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	checkLanmanParameters(registryKey)
+	checkLanmanServerParameters(registryKey)
 }
 
 // checkLanmanParameters is a helper function that checks the registry to determine if the system is configured with the correct settings for Lanman parameters.
 //
 // CIS Benchmark Audit list indices: 2.3.8.1-3
-func checkLanmanParameters(registryKey mocking.RegistryKey) []bool {
+func checkLanmanParameters(registryKey mocking.RegistryKey) {
 	registryPath := `SYSTEM\CurrentControlSet\Services\LanmanWorkstation\Parameters`
 
 	settings := []string{"RequireSecuritySignature", "EnableSecuritySignature", "EnablePlainTextPassword"}
 
 	expectedValues := []interface{}{uint64(1), uint64(1), uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // checkLanmanServerParameters is a helper function that checks the registry to determine if the system is configured with the correct settings for Lanman server parameters.
 //
 // CIS Benchmark Audit list indices: 2.3.9.1-5, 2.3.10.6, 2.3.10.9, 2.3.10.11, 18.3.3
-func checkLanmanServerParameters(registryKey mocking.RegistryKey) []bool {
+func checkLanmanServerParameters(registryKey mocking.RegistryKey) {
 	registryPath := `SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters`
 
 	settings := []string{"AutoDisconnect", "RequireSecuritySignature", "EnableSecuritySignature", "enableforcedlogoff",
@@ -769,27 +752,27 @@ func checkLanmanServerParameters(registryKey mocking.RegistryKey) []bool {
 	expectedValues := []interface{}{[]uint64{1, 15}, uint64(1), uint64(1), uint64(1), []uint64{1, 2}, nil, uint64(1),
 		nil, uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesNetworkConnections is a helper function that checks the registry to determine if the system is configured with the correct settings for network connections.
 //
 // CIS Benchmark Audit list indices: 18.5.11.2-4
-func policiesNetworkConnections(registryKey mocking.RegistryKey) []bool {
+func policiesNetworkConnections(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\Network Connections`
 
 	settings := []string{"NC_AllowNetBridge_NLA", "NC_ShowSharedAccessUI", "NC_StdDomainUserSetLocation"}
 
 	expectedValues := []interface{}{uint64(0), uint64(0), uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesNetworkProvider is a helper function that checks the registry to determine if the system is configured with the correct settings for the network provider.
 //
 // CIS Benchmark Audit list index: 18.5.14.1
 // TODO: NEEDS CHECKING, IF THIS WORKS AS INTENDED, COULD NOT TEST DUE TO NON-EXISTENT REGISTRY KEY
-func policiesNetworkProvider(registryKey mocking.RegistryKey) []bool {
+func policiesNetworkProvider(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\NetworkProvider\HardenedPaths`
 
 	settings := []string{"\\\\*\\NETLOGON", "\\\\*\\SYSVOL"}
@@ -799,102 +782,99 @@ func policiesNetworkProvider(registryKey mocking.RegistryKey) []bool {
 		"[Rr]equire([Mm]utual[Aa]uthentication|[Ii]ntegrity)=1.*[Rr]equire([Mm]utual[Aa]uthentication|[Ii]ntegrity)=1",
 	}
 
-	return CheckStringRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckStringRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesOneDrive is a helper function that checks the registry to determine if the system is configured with the correct settings for OneDrive.
 //
 // CIS Benchmark Audit list index: 18.9.58.1
-func policiesOneDrive(registryKey mocking.RegistryKey) []bool {
+func policiesOneDrive(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\OneDrive`
 
 	settings := []string{"DisableFileSyncNGSC"}
 
 	expectedValues := []interface{}{uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesPersonalization is a helper function that checks the registry to determine if the system is configured with the correct settings for personalization.
 //
 // CIS Benchmark Audit list indices: 18.1.1.1-2
-func policiesPersonalization(registryKey mocking.RegistryKey) []bool {
+func policiesPersonalization(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\Personalization`
 
 	settings := []string{"NoLockScreenCamera", "NoLockScreenSlideshow"}
 
 	expectedValues := []interface{}{uint64(1), uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesPowerShell is a helper function that checks the registry to determine if the system is configured with the correct settings for PowerShell.
 //
 // CIS Benchmark Audit list indices: 18.9.100.1-2
-func policiesPowerShell(registryKey mocking.RegistryKey) []bool {
-	results := make([]bool, 0)
-
-	results = append(results, checkPowershellScriptblocklogging(registryKey)...)
-	results = append(results, checkPowershellTranscription(registryKey)...)
-	return results
+func policiesPowerShell(registryKey mocking.RegistryKey) {
+	checkPowershellScriptblocklogging(registryKey)
+	checkPowershellTranscription(registryKey)
 }
 
 // checkPowershellScriptblocklogging is a helper function that checks the registry to determine if the system is configured with the correct settings for PowerShell script block logging.
 //
 // CIS Benchmark Audit list index: 18.9.100.1
-func checkPowershellScriptblocklogging(registryKey mocking.RegistryKey) []bool {
+func checkPowershellScriptblocklogging(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\Powershell\Scriptblocklogging`
 
 	settings := []string{"EnableScriptBlockLogging"}
 
 	expectedValues := []interface{}{uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // checkPowershellTranscription is a helper function that checks the registry to determine if the system is configured with the correct settings for PowerShell transcription.
 //
 // CIS Benchmark Audit list index: 18.9.100.1
-func checkPowershellTranscription(registryKey mocking.RegistryKey) []bool {
+func checkPowershellTranscription(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\Powershell\Transcription`
 
 	settings := []string{"EnableTranscripting"}
 
 	expectedValues := []interface{}{uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesPreviewBuild is a helper function that checks the registry to determine if the system is configured with the correct settings for preview builds.
 //
 // CIS Benchmark Audit list index: 18.9.17.8
-func policiesPreviewBuild(registryKey mocking.RegistryKey) []bool {
+func policiesPreviewBuild(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\Previewbuilds`
 
 	settings := []string{"AllowBuildPreview"}
 
 	expectedValues := []interface{}{uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesSandbox is a helper function that checks the registry to determine if the system is configured with the correct settings for the sandbox.
 //
 // CIS Benchmark Audit list indices: 18.9.104.1-2
-func policiesSandbox(registryKey mocking.RegistryKey) []bool {
+func policiesSandbox(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\Sandbox`
 
 	settings := []string{"AllowClipboardRedirection", "AllowNetworking"}
 
 	expectedValues := []interface{}{uint64(0), uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesGeneralSystem is a helper function that checks the registry to determine if the system is configured with the correct settings for Windows System.
 //
 // CIS Benchmark Audit list indices: 18.8.21.4, 18.8.28.1-7, 18.9.16.3, 18.9.85.1.1
-func policiesGeneralSystem(registryKey mocking.RegistryKey) []bool {
+func policiesGeneralSystem(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\System`
 
 	settings := []string{"EnableCdp", "BlockUserFromShowingAccountDetailsOnSignin", "DontDisplayNetworkSelectionUI",
@@ -905,26 +885,26 @@ func policiesGeneralSystem(registryKey mocking.RegistryKey) []bool {
 	expectedValues := []interface{}{uint64(0), uint64(1), uint64(1), uint64(1), uint64(0), uint64(1), uint64(1),
 		uint64(0), uint64(1), uint64(1), uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesWindowsSearch is a helper function that checks the registry to determine if the system is configured with the correct settings for Windows Search.
 //
 // CIS Benchmark Audit list indices: 18.9.67.3-6
-func policiesWindowsSearch(registryKey mocking.RegistryKey) []bool {
+func policiesWindowsSearch(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\Windows Search`
 
 	settings := []string{"AllowCortana", "AllowCortanaAboveLock", "AllowIndexingEncryptedStoresOrItems", "AllowSearchToUseLocation"}
 
 	expectedValues := []interface{}{uint64(0), uint64(0), uint64(0), uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesWindowsUpdate is a helper function that checks the registry to determine if the system is configured with the correct settings for Windows Update.
 //
 // CIS Benchmark Audit list indices: 18.9.108.2.2-3, 18.9.108.4.1-3
-func policiesWindowsUpdate(registryKey mocking.RegistryKey) []bool {
+func policiesWindowsUpdate(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate`
 
 	settings := []string{"SetDisablePauseUXAccess", "ManagePreviewBuildsPolicyValue", "DeferFeatureUpdates",
@@ -932,93 +912,84 @@ func policiesWindowsUpdate(registryKey mocking.RegistryKey) []bool {
 
 	expectedValues := []interface{}{uint64(1), uint64(1), uint64(1), []uint64{180, ^uint64(0)}, uint64(1), uint64(0)}
 
-	results := make([]bool, 0)
-	results = append(results, CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)...)
-	results = append(results, checkWindowsUpdateAu(registryKey)...)
-	return results
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	checkWindowsUpdateAu(registryKey)
 }
 
 // checkWindowsUpdateAu is a helper function that checks the registry to determine if the system is configured with the correct settings for Windows Update AU.
 //
 // CIS Benchmark Audit list indices: 18.9.108.1.1, 18.9.108.2.1-2
-func checkWindowsUpdateAu(registryKey mocking.RegistryKey) []bool {
+func checkWindowsUpdateAu(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\Windowsupdate\Au`
 
 	settings := []string{"NoAutoRebootWithLoggedOnUsers", "NoAutoUpdate", "ScheduledInstallDay"}
 
 	expectedValues := []interface{}{uint64(0), uint64(0), uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesWinRM is a helper function that checks the registry to determine if the system is configured with the correct settings for WinRM.
-func policiesWinRM(registryKey mocking.RegistryKey) []bool {
-	results := make([]bool, 0)
+func policiesWinRM(registryKey mocking.RegistryKey) {
 
-	results = append(results, checkWinRMClient(registryKey)...)
-	results = append(results, checkWinRMService(registryKey)...)
+	checkWinRMClient(registryKey)
+	checkWinRMService(registryKey)
 
-	return results
 }
 
 // checkWinRMClient is a helper function that checks the registry to determine if the system is configured with the correct settings for WinRM client.
 //
 // CIS Benchmark Audit list indices: 18.9.102.1.1-3
-func checkWinRMClient(registryKey mocking.RegistryKey) []bool {
+func checkWinRMClient(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\WinRM\Client`
 
 	settings := []string{"AllowBasic", "AllowUnencryptedTraffic", "AllowDigest"}
 
 	expectedValues := []interface{}{uint64(0), uint64(0), uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // checkWinRMService is a helper function that checks the registry to determine if the system is configured with the correct settings for WinRM service.
 //
 // CIS Benchmark Audit list indices: 18.9.102.2.1, 18.9.102.2.3-4
-func checkWinRMService(registryKey mocking.RegistryKey) []bool {
+func checkWinRMService(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\WinRM\Service`
 
 	settings := []string{"AllowBasic", "AllowUnencryptedTraffic", "DisableRunAs"}
 
 	expectedValues := []interface{}{uint64(0), uint64(0), uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesWindowsFirewall is a helper function that checks the registry to determine if the system is configured with the correct settings for the Windows firewall.
 //
 // CIS Benchmark Audit list indices: 9.1.1-4, 9.1.5-8, 9.2.1-4, 9.2.5-8, 9.3.1-6, 9.3.7-10
-func policiesWindowsFirewall(registryKey mocking.RegistryKey) []bool {
-	results := make([]bool, 0)
-
-	results = append(results, checkWindowsFirewallPrivateProfile(registryKey)...)
-	results = append(results, checkWindowsFirewallPublicProfile(registryKey)...)
-	results = append(results, checkWindowsFirewallDomainProfile(registryKey)...)
-	return results
+func policiesWindowsFirewall(registryKey mocking.RegistryKey) {
+	checkWindowsFirewallPrivateProfile(registryKey)
+	checkWindowsFirewallPublicProfile(registryKey)
+	checkWindowsFirewallDomainProfile(registryKey)
 }
 
 // checkWindowsFirewallDomainProfile is a helper function that checks the registry to determine if the system is configured with the correct settings for the domain profile.
 //
 // CIS Benchmark Audit list indices: 9.1.1-4
-func checkWindowsFirewallDomainProfile(registryKey mocking.RegistryKey) []bool {
+func checkWindowsFirewallDomainProfile(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\WindowsFirewall\DomainProfile`
 
 	settings := []string{"EnableFirewall", "DefaultInboundAction", "DefaultOutboundAction", "DisableNotifications"}
 
 	expectedValues := []interface{}{uint64(1), uint64(1), uint64(0), uint64(1)}
 
-	results := make([]bool, 0)
-	results = append(results, checkWindowsFirewallDomainProfileLogging(registryKey)...)
-	results = append(results, CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)...)
-	return results
+	checkWindowsFirewallDomainProfileLogging(registryKey)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // checkWindowsFirewallDomainProfileLogging is a helper function that checks the registry to determine if the system is configured with the correct settings for the domain profile logging.
 //
 // CIS Benchmark Audit list indices: 9.1.5-8
-func checkWindowsFirewallDomainProfileLogging(registryKey mocking.RegistryKey) []bool {
+func checkWindowsFirewallDomainProfileLogging(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\WindowsFirewall\DomainProfile\Logging`
 
 	stringSetting := []string{"LogFilePath"}
@@ -1027,31 +998,28 @@ func checkWindowsFirewallDomainProfileLogging(registryKey mocking.RegistryKey) [
 	expectedString := []string{`%SYSTEMROOT%\System32\logfiles\firewall\domainfw.log`}
 	expectedValues := []interface{}{[]uint64{16384, ^uint64(0)}, uint64(1), uint64(1)}
 
-	return CheckIntegerStringRegistrySettings(registryKey, registryPath, settings, expectedValues,
+	CheckIntegerStringRegistrySettings(registryKey, registryPath, settings, expectedValues,
 		stringSetting, expectedString)
 }
 
 // checkWindowsFirewallPublicProfile is a helper function that checks the registry to determine if the system is configured with the correct settings for the public profile.
 //
 // CIS Benchmark Audit list indices: 9.2.1-4
-func checkWindowsFirewallPrivateProfile(registryKey mocking.RegistryKey) []bool {
+func checkWindowsFirewallPrivateProfile(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile`
 
 	settings := []string{"EnableFirewall", "DefaultInboundAction", "DefaultOutboundAction", "DisableNotifications"}
 
 	expectedValues := []interface{}{uint64(1), uint64(1), uint64(0), uint64(1)}
 
-	results := make([]bool, 0)
-	results = append(results, checkWindowsFirewallPrivateProfileLogging(registryKey)...)
-	results = append(results, CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)...)
-
-	return results
+	checkWindowsFirewallPrivateProfileLogging(registryKey)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // checkWindowsFirewallPrivateProfileLogging is a helper function that checks the registry to determine if the system is configured with the correct settings for the private profile logging.
 //
 // CIS Benchmark Audit list indices: 9.2.5-8
-func checkWindowsFirewallPrivateProfileLogging(registryKey mocking.RegistryKey) []bool {
+func checkWindowsFirewallPrivateProfileLogging(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging`
 
 	stringSetting := []string{"LogFilePath"}
@@ -1060,30 +1028,28 @@ func checkWindowsFirewallPrivateProfileLogging(registryKey mocking.RegistryKey) 
 	expectedString := []string{`%SYSTEMROOT%\System32\logfiles\firewall\privatefw.log`}
 	expectedValues := []interface{}{[]uint64{16384, ^uint64(0)}, uint64(1), uint64(1)}
 
-	return CheckIntegerStringRegistrySettings(registryKey, registryPath, settings, expectedValues, stringSetting, expectedString)
+	CheckIntegerStringRegistrySettings(registryKey, registryPath, settings, expectedValues, stringSetting, expectedString)
 }
 
 // checkWindowsFirewallPublicProfile is a helper function that checks the registry to determine if the system is configured with the correct settings for the public profile.
 //
 // CIS Benchmark Audit list indices: 9.3.1-6
-func checkWindowsFirewallPublicProfile(registryKey mocking.RegistryKey) []bool {
+func checkWindowsFirewallPublicProfile(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\WindowsFirewall\PublicProfile`
 	settings := []string{"EnableFirewall", "DefaultInboundAction", "DefaultOutboundAction", "DisableNotifications",
 		"AllowLocalPolicyMerge", "AllowLocalIPsecPolicyMerge"}
 
 	expectedValues := []interface{}{uint64(1), uint64(1), uint64(0), uint64(1), uint64(0), uint64(0)}
 
-	results := make([]bool, 0)
-	results = append(results, checkWindowsFirewallPublicProfileLogging(registryKey)...)
-	results = append(results, CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)...)
+	checkWindowsFirewallPublicProfileLogging(registryKey)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 
-	return results
 }
 
 // checkWindowsFirewallPublicProfileLogging is a helper function that checks the registry to determine if the system is configured with the correct settings for the public profile logging.
 //
 // CIS Benchmark Audit list indices: 9.3.7-10
-func checkWindowsFirewallPublicProfileLogging(registryKey mocking.RegistryKey) []bool {
+func checkWindowsFirewallPublicProfileLogging(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\WindowsFirewall\PublicProfile\Logging`
 	stringSetting := []string{"LogFilePath"}
 	settings := []string{"LogFileSize", "LogDroppedPackets", "LogSuccessfulConnections"}
@@ -1091,45 +1057,45 @@ func checkWindowsFirewallPublicProfileLogging(registryKey mocking.RegistryKey) [
 	expectedString := []string{`%SYSTEMROOT%\System32\logfiles\firewall\publicfw.log`}
 	expectedValues := []interface{}{[]uint64{16384, ^uint64(0)}, uint64(1), uint64(1)}
 
-	return CheckIntegerStringRegistrySettings(registryKey, registryPath, settings, expectedValues,
+	CheckIntegerStringRegistrySettings(registryKey, registryPath, settings, expectedValues,
 		stringSetting, expectedString)
 }
 
 // policiesWindowsInkWorkspace is a helper function that checks the registry to determine if the system is configured with the correct settings for Windows Ink Workspace.
 //
 // CIS Benchmark Audit list index: 18.9.89.2
-func policiesWindowsInkWorkspace(registryKey mocking.RegistryKey) []bool {
+func policiesWindowsInkWorkspace(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\WindowsInkWorkspace`
 
 	settings := []string{"AllowWindowsInkWorkspace"}
 
 	expectedValues := []interface{}{[]uint64{0, 1}}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesWindowsStore is a helper function that checks the registry to determine if the system is configured with the correct settings for the Windows Store.
 //
 // CIS Benchmark Audit list indices: 18.9.75.2-4
-func policiesWindowsStore(registryKey mocking.RegistryKey) []bool {
+func policiesWindowsStore(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\WindowsStore`
 
 	settings := []string{"RequirePrivateStoreOnly", "AutoDownload", "DisableOSUpgrade"}
 
 	expectedValues := []interface{}{uint64(1), uint64(4), uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // policiesEarlyLaunch is a helper function that checks the registry to determine if the system is configured with the correct settings for early launch.
 //
 // CIS Benchmark Audit list index: 18.8.14.1
-func policiesEarlyLaunch(registryKey mocking.RegistryKey) []bool {
+func policiesEarlyLaunch(registryKey mocking.RegistryKey) {
 	registryPath := `SYSTEM\CurrentControlSet\Policies\EarlyLaunch`
 
 	settings := []string{"DriverLoadPolicy"}
 
 	expectedValues := []interface{}{uint64(3)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }

--- a/checks/cisregistrysettings/cis_registry_policies_HKLM.go
+++ b/checks/cisregistrysettings/cis_registry_policies_HKLM.go
@@ -14,13 +14,10 @@ import "github.com/InfoSec-Agent/InfoSec-Agent/mocking"
 // Returns:
 //
 //   - []bool: A slice of boolean values, where each boolean represents whether a particular registry setting adheres to the CIS Benchmark standards.
-func CheckPoliciesHKLM(registryKey mocking.RegistryKey) []bool {
-	results := make([]bool, 0)
+func CheckPoliciesHKLM(registryKey mocking.RegistryKey) {
 	for _, check := range policyChecksHKLM {
 		check(registryKey)
 	}
-
-	return results
 }
 
 // policyChecksHKLM is a collection of registry checks related to different policies.

--- a/checks/cisregistrysettings/cis_registry_policies_HKLM.go
+++ b/checks/cisregistrysettings/cis_registry_policies_HKLM.go
@@ -11,9 +11,7 @@ import "github.com/InfoSec-Agent/InfoSec-Agent/mocking"
 //
 //   - registryKey (mocking.RegistryKey): The root key from which the registry settings will be checked. Should be HKEY_LOCAL_MACHINE for this function.
 //
-// Returns:
-//
-//   - []bool: A slice of boolean values, where each boolean represents whether a particular registry setting adheres to the CIS Benchmark standards.
+// Returns: None
 func CheckPoliciesHKLM(registryKey mocking.RegistryKey) {
 	for _, check := range policyChecksHKLM {
 		check(registryKey)

--- a/checks/cisregistrysettings/cis_registry_policies_HKLM.go
+++ b/checks/cisregistrysettings/cis_registry_policies_HKLM.go
@@ -294,7 +294,6 @@ func policiesWindowsDefender(registryKey mocking.RegistryKey) {
 	checkWindowsDefenderSpyNet(registryKey)
 	checkWindowsDefenderNetworkProtection(registryKey)
 	checkWindowsDefenderAppBrowserProtection(registryKey)
-
 }
 
 // checkWindowsDefenderScan is a helper function that checks the registry to determine if Windows Defender is configured with the correct scan settings.
@@ -928,10 +927,8 @@ func checkWindowsUpdateAu(registryKey mocking.RegistryKey) {
 
 // policiesWinRM is a helper function that checks the registry to determine if the system is configured with the correct settings for WinRM.
 func policiesWinRM(registryKey mocking.RegistryKey) {
-
 	checkWinRMClient(registryKey)
 	checkWinRMService(registryKey)
-
 }
 
 // checkWinRMClient is a helper function that checks the registry to determine if the system is configured with the correct settings for WinRM client.
@@ -1040,7 +1037,6 @@ func checkWindowsFirewallPublicProfile(registryKey mocking.RegistryKey) {
 
 	checkWindowsFirewallPublicProfileLogging(registryKey)
 	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
-
 }
 
 // checkWindowsFirewallPublicProfileLogging is a helper function that checks the registry to determine if the system is configured with the correct settings for the public profile logging.

--- a/checks/cisregistrysettings/cis_registry_services.go
+++ b/checks/cisregistrysettings/cis_registry_services.go
@@ -11,9 +11,7 @@ import "github.com/InfoSec-Agent/InfoSec-Agent/mocking"
 //
 //   - registryKey (mocking.RegistryKey): The root key from which the registry settings will be checked. Should be HKEY_LOCAL_MACHINE for this function.
 //
-// Returns:
-//
-//   - []bool: A slice of boolean values, where each boolean represents whether a particular registry setting adheres to the CIS Benchmark standards.
+// Returns: None
 func CheckServices(registryKey mocking.RegistryKey) {
 	checkservicesDisabled(registryKey, servicesDisabledRegistryPaths)
 	for _, check := range serviceChecks {

--- a/checks/cisregistrysettings/cis_registry_services.go
+++ b/checks/cisregistrysettings/cis_registry_services.go
@@ -14,20 +14,17 @@ import "github.com/InfoSec-Agent/InfoSec-Agent/mocking"
 // Returns:
 //
 //   - []bool: A slice of boolean values, where each boolean represents whether a particular registry setting adheres to the CIS Benchmark standards.
-func CheckServices(registryKey mocking.RegistryKey) []bool {
-	results := make([]bool, 0)
-	results = append(results, checkservicesDisabled(registryKey, servicesDisabledRegistryPaths)...)
+func CheckServices(registryKey mocking.RegistryKey) {
+	checkservicesDisabled(registryKey, servicesDisabledRegistryPaths)
 	for _, check := range serviceChecks {
-		results = append(results, check(registryKey)...)
+		check(registryKey)
 	}
-
-	return results
 }
 
 // serviceChecks is a collection of registry checks related to different services.
 // Each function in the collection represents a different service check that the application can perform.
 // The registry settings get checked against the CIS Benchmark recommendations.
-var serviceChecks = []func(mocking.RegistryKey) []bool{
+var serviceChecks = []func(mocking.RegistryKey){
 	servicesEventLog,
 	servicesLDAP,
 	servicesNetBTParameters,
@@ -67,46 +64,46 @@ var servicesDisabledRegistryPaths = []string{
 // servicesEventLog is a helper function that checks the registry to determine if the system is configured with the correct settings for the event log service.
 //
 // CIS Benchmark Audit list index: 18.4.13
-func servicesEventLog(registryKey mocking.RegistryKey) []bool {
+func servicesEventLog(registryKey mocking.RegistryKey) {
 	registryPath := `SYSTEM\CurrentControlSet\Services\Eventlog\Security`
 
 	settings := []string{"WarningLevel"}
 
 	expectedValues := []interface{}{[]uint64{1, 90}}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // servicesLDAP is a helper function that checks the registry to determine if the system is configured with the correct settings for the LDAP service.
 //
 // CIS Benchmark Audit list index: 2.3.11.8
-func servicesLDAP(registryKey mocking.RegistryKey) []bool {
+func servicesLDAP(registryKey mocking.RegistryKey) {
 	registryPath := `SYSTEM\CurrentControlSet\Services\LDAP`
 
 	settings := []string{"LDAPClientIntegrity"}
 
 	expectedValues := []interface{}{uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // servicesNetBTParameters is a helper function that checks the registry to determine if the system is configured with the correct settings for the NetBT parameters.
 //
 // CIS Benchmark Audit list indices: 18.3.6, 18.4.7
-func servicesNetBTParameters(registryKey mocking.RegistryKey) []bool {
+func servicesNetBTParameters(registryKey mocking.RegistryKey) {
 	registryPath := `SYSTEM\CurrentControlSet\Services\NetBT\Parameters`
 
 	settings := []string{"NodeType", "nonamereleaseondemand"}
 
 	expectedValues := []interface{}{uint64(2), uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // servicesNetlogonParameters is a helper function that checks the registry to determine if the system is configured with the correct settings for the Netlogon parameters.
 //
 // CIS Benchmark Audit list indices: 2.3.6.1-6
-func servicesNetlogonParameters(registryKey mocking.RegistryKey) []bool {
+func servicesNetlogonParameters(registryKey mocking.RegistryKey) {
 	registryPath := `SYSTEM\CurrentControlSet\Services\Netlogon\Parameters`
 
 	settings := []string{"RequireSignOrSeal", "SealSecureChannel", "SignSecureChannel",
@@ -114,44 +111,42 @@ func servicesNetlogonParameters(registryKey mocking.RegistryKey) []bool {
 
 	expectedValues := []interface{}{uint64(1), uint64(1), uint64(1), uint64(0), []uint64{1, 30}, uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // servicesTCPIP is a helper function that checks the registry to determine if the system is configured with the correct settings for the TCPIP service.
 //
 // CIS Benchmark Audit list indices: 18.4.3, 18.4.5
-func servicesTCPIP(registryKey mocking.RegistryKey) []bool {
+func servicesTCPIP(registryKey mocking.RegistryKey) {
 	registryPath := `SYSTEM\CurrentControlSet\Services\Tcpip\Parameters`
 
 	settings := []string{"DisableIPSourceRouting", "EnableICMPRedirect"}
 
 	expectedValues := []interface{}{uint64(2), uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // servicesTCPIP6 is a helper function that checks the registry to determine if the system is configured with the correct settings for the TCPIP6 service.
 //
 // CIS Benchmark Audit list indices: 18.4.2
-func servicesTCPIP6(registryKey mocking.RegistryKey) []bool {
+func servicesTCPIP6(registryKey mocking.RegistryKey) {
 	registryPath := `SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters`
 
 	settings := []string{"DisableIPSourceRouting"}
 
 	expectedValues := []interface{}{uint64(2)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // checkservicesDisabled is a helper function that checks the registry to determine if the system is configured with the correct settings for the services that should be disabled.
-func checkservicesDisabled(registryKey mocking.RegistryKey, registryPaths []string) []bool {
-	results := make([]bool, 0)
+func checkservicesDisabled(registryKey mocking.RegistryKey, registryPaths []string) {
 	for _, registryPath := range registryPaths {
 		settings := []string{"Start"}
 
 		expectedValues := []interface{}{uint64(4)}
 
-		results = append(results, CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)...)
+		CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 	}
-	return results
 }

--- a/checks/cisregistrysettings/cis_registry_test.go
+++ b/checks/cisregistrysettings/cis_registry_test.go
@@ -338,15 +338,7 @@ func TestCheckServices(t *testing.T) {
 		}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := cisregistrysettings.CheckServices(tt.key)
-			if len(got) != len(tt.want) {
-				t.Errorf("Length of CheckServices() = %v, want %v", len(got), len(tt.want))
-			}
-			for i, result := range got {
-				if result != tt.want[i] {
-					t.Errorf("CheckServices() at index %v = %v, want %v", i, result, tt.want[i])
-				}
-			}
+			cisregistrysettings.CheckServices(tt.key)
 		})
 	}
 }
@@ -558,12 +550,7 @@ func TestCheckIntegerStringRegistrySettings(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := cisregistrysettings.CheckIntegerStringRegistrySettings(tt.key, tt.path, tt.integerSettings, tt.expectedIntegers, tt.stringSettings, tt.expectedStrings)
-			for i, result := range got {
-				if result != tt.want[i] {
-					t.Errorf("CheckIntegerStringRegistrySettings() at index %v = %v, want %v", i, result, tt.want[i])
-				}
-			}
+			cisregistrysettings.CheckIntegerStringRegistrySettings(tt.key, tt.path, tt.integerSettings, tt.expectedIntegers, tt.stringSettings, tt.expectedStrings)
 		})
 	}
 }
@@ -603,12 +590,7 @@ func TestCheckStringRegistrySettings(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := cisregistrysettings.CheckStringRegistrySettings(tt.key, tt.path, tt.stringSettings, tt.expectedStrings)
-			for i, result := range got {
-				if result != tt.want[i] {
-					t.Errorf("CheckStringRegistrySettings() at index %v = %v, want %v", i, result, tt.want[i])
-				}
-			}
+			cisregistrysettings.CheckStringRegistrySettings(tt.key, tt.path, tt.stringSettings, tt.expectedStrings)
 		})
 	}
 }
@@ -648,12 +630,7 @@ func TestCheckIntegerRegistrySettings(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := cisregistrysettings.CheckIntegerRegistrySettings(tt.key, tt.path, tt.integerSettings, tt.expectedIntegers)
-			for i, result := range got {
-				if result != tt.want[i] {
-					t.Errorf("CheckIntegerRegistrySettings() at index %v = %v, want %v", i, result, tt.want[i])
-				}
-			}
+			cisregistrysettings.CheckIntegerRegistrySettings(tt.key, tt.path, tt.integerSettings, tt.expectedIntegers)
 		})
 	}
 }

--- a/checks/cisregistrysettings/cis_registry_test.go
+++ b/checks/cisregistrysettings/cis_registry_test.go
@@ -22,7 +22,7 @@ func TestCheckWin11(t *testing.T) {
 	tests := []struct {
 		name string
 		key  mocking.RegistryKey
-		want []bool
+		want bool
 	}{
 		{
 			name: "DNS Client set up correctly",
@@ -31,7 +31,7 @@ func TestCheckWin11(t *testing.T) {
 					{KeyName: "SOFTWARE\\Policies\\Microsoft\\Windows NT\\DNSClient",
 						IntegerValues: map[string]uint64{"DoHPolicy": uint64(2)}},
 				}},
-			want: []bool{true},
+			want: true,
 		},
 		{
 			name: "DNS Client not set up correctly",
@@ -40,19 +40,15 @@ func TestCheckWin11(t *testing.T) {
 					{KeyName: "SOFTWARE\\Policies\\Microsoft\\Windows NT\\DNSClient",
 						IntegerValues: map[string]uint64{"DoHPolicy": uint64(1)}},
 				}},
-			want: []bool{false},
+			want: false,
 		},
 	}
 	for _, tt := range tests {
+		cisregistrysettings.RegistrySettingsMap = map[string]bool{}
 		t.Run(tt.name, func(t *testing.T) {
-			got := cisregistrysettings.CheckWin11(tt.key)
-			if len(got) != len(tt.want) {
-				t.Errorf("Length of CheckWin11() = %v, want %v", len(got), len(tt.want))
-			}
-			for i, result := range got {
-				if result != tt.want[i] {
-					t.Errorf("CheckWin11() at index %v = %v, want %v", i, result, tt.want[i])
-				}
+			cisregistrysettings.CheckWin11(tt.key)
+			if cisregistrysettings.RegistrySettingsMap["SOFTWARE\\Policies\\Microsoft\\Windows NT\\DNSClient\\DoHPolicy"] != tt.want {
+				t.Errorf("CheckWin11() = %v, want %v", cisregistrysettings.RegistrySettingsMap["SOFTWARE\\Policies\\Microsoft\\Windows NT\\DNSClient"], tt.want)
 			}
 		})
 	}
@@ -62,13 +58,13 @@ func TestCheckWin10(t *testing.T) {
 	tests := []struct {
 		name string
 		key  mocking.RegistryKey
-		want []bool
+		want bool
 	}{
 		{
 			name: "Nothing set up correctly",
 			key: &mocking.MockRegistryKey{
 				SubKeys: []mocking.MockRegistryKey{}},
-			want: make([]bool, 17),
+			want: false,
 		},
 		{
 			name: "Everything set up correctly",
@@ -113,24 +109,14 @@ func TestCheckWin10(t *testing.T) {
 				},
 			},
 
-			want: func() []bool {
-				results := make([]bool, 17)
-				for i := range results {
-					results[i] = true
-				}
-				return results
-			}(),
+			want: true,
 		}}
 	for _, tt := range tests {
+		cisregistrysettings.RegistrySettingsMap = map[string]bool{}
 		t.Run(tt.name, func(t *testing.T) {
-			got := cisregistrysettings.CheckWin10(tt.key)
-			if len(got) != len(tt.want) {
-				t.Errorf("Length of CheckWin10() = %v, want %v", len(got), len(tt.want))
-			}
-			for i, result := range got {
-				if result != tt.want[i] {
-					t.Errorf("CheckWin10() at index %v = %v, want %v", i, result, tt.want[i])
-				}
+			cisregistrysettings.CheckWin10(tt.key)
+			if allValuesTrue(cisregistrysettings.RegistrySettingsMap) != tt.want {
+				t.Errorf("CheckWin10() = %v, want %v", allValuesTrue(cisregistrysettings.RegistrySettingsMap), tt.want)
 			}
 		})
 	}
@@ -140,12 +126,12 @@ func TestCheckPoliciesHKU(t *testing.T) {
 	tests := []struct {
 		name string
 		key  mocking.RegistryKey
-		want []bool
+		want bool
 	}{
 		{
 			name: "Nothing set up correctly",
 			key:  &mocking.MockRegistryKey{},
-			want: make([]bool, 11),
+			want: false,
 		},
 		{
 			name: "Everything set up correctly",
@@ -177,24 +163,14 @@ func TestCheckPoliciesHKU(t *testing.T) {
 					},
 				},
 			},
-			want: func() []bool {
-				results := make([]bool, 11)
-				for i := range results {
-					results[i] = true
-				}
-				return results
-			}(),
+			want: true,
 		}}
 	for _, tt := range tests {
+		cisregistrysettings.RegistrySettingsMap = map[string]bool{}
 		t.Run(tt.name, func(t *testing.T) {
-			got := cisregistrysettings.CheckPoliciesHKU(tt.key)
-			if len(got) != len(tt.want) {
-				t.Errorf("Length of CheckPoliciesHKU() = %v, want %v", len(got), len(tt.want))
-			}
-			for i, result := range got {
-				if result != tt.want[i] {
-					t.Errorf("CheckPoliciesHKU() at index %v = %v, want %v", i, result, tt.want[i])
-				}
+			cisregistrysettings.CheckPoliciesHKU(tt.key)
+			if allValuesTrue(cisregistrysettings.RegistrySettingsMap) != tt.want {
+				t.Errorf("CheckPoliciesHKU() = %v, want %v", allValuesTrue(cisregistrysettings.RegistrySettingsMap), tt.want)
 			}
 		})
 	}
@@ -204,12 +180,12 @@ func TestCheckServices(t *testing.T) {
 	tests := []struct {
 		name string
 		key  mocking.RegistryKey
-		want []bool
+		want bool
 	}{
 		{
 			name: "Nothing set up correctly",
 			key:  &mocking.MockRegistryKey{},
-			want: make([]bool, 35),
+			want: false,
 		},
 		{
 			name: "Everything set up correctly",
@@ -328,17 +304,15 @@ func TestCheckServices(t *testing.T) {
 						IntegerValues: map[string]uint64{"Start": uint64(4)},
 					},
 				}},
-			want: func() []bool {
-				results := make([]bool, 35)
-				for i := range results {
-					results[i] = true
-				}
-				return results
-			}(),
+			want: true,
 		}}
 	for _, tt := range tests {
+		cisregistrysettings.RegistrySettingsMap = map[string]bool{}
 		t.Run(tt.name, func(t *testing.T) {
 			cisregistrysettings.CheckServices(tt.key)
+			if allValuesTrue(cisregistrysettings.RegistrySettingsMap) != tt.want {
+				t.Errorf("CheckServices() = %v, want %v", allValuesTrue(cisregistrysettings.RegistrySettingsMap), tt.want)
+			}
 		})
 	}
 }
@@ -347,12 +321,12 @@ func TestCheckOtherRegistrySettings(t *testing.T) {
 	tests := []struct {
 		name string
 		key  mocking.RegistryKey
-		want []bool
+		want bool
 	}{
 		{
 			name: "Nothing set up correctly",
 			key:  &mocking.MockRegistryKey{},
-			want: make([]bool, 31),
+			want: false,
 		},
 		{
 			name: "Everything set up correctly",
@@ -416,25 +390,15 @@ func TestCheckOtherRegistrySettings(t *testing.T) {
 					},
 				},
 			},
-			want: func() []bool {
-				results := make([]bool, 31)
-				for i := range results {
-					results[i] = true
-				}
-				return results
-			}(),
+			want: true,
 		},
 	}
 	for _, tt := range tests {
+		cisregistrysettings.RegistrySettingsMap = map[string]bool{}
 		t.Run(tt.name, func(t *testing.T) {
-			got := cisregistrysettings.CheckOtherRegistrySettings(tt.key)
-			if len(got) != len(tt.want) {
-				t.Errorf("Length of CheckOtherRegistrySettings() = %v, want %v", len(got), len(tt.want))
-			}
-			for i, result := range got {
-				if result != tt.want[i] {
-					t.Errorf("CheckOtherRegistrySettings() at index %v = %v, want %v", i, result, tt.want[i])
-				}
+			cisregistrysettings.CheckOtherRegistrySettings(tt.key)
+			if allValuesTrue(cisregistrysettings.RegistrySettingsMap) != tt.want {
+				t.Errorf("CheckOtherRegistrySettings() = %v, want %v", allValuesTrue(cisregistrysettings.RegistrySettingsMap), tt.want)
 			}
 		})
 	}
@@ -444,12 +408,12 @@ func TestCheckPoliciesHKLM(t *testing.T) {
 	tests := []struct {
 		name string
 		key  mocking.RegistryKey
-		want []bool
+		want bool
 	}{
 		{
 			name: "Nothing set up correctly",
 			key:  &mocking.MockRegistryKey{},
-			want: make([]bool, 201),
+			want: false,
 		},
 		{
 			name: "Some setting is set up correctly",
@@ -461,23 +425,15 @@ func TestCheckPoliciesHKLM(t *testing.T) {
 					},
 				},
 			},
-			want: func() []bool {
-				results := make([]bool, 201)
-				results[0] = true
-				return results
-			}(),
+			want: true,
 		},
 	}
 	for _, tt := range tests {
+		cisregistrysettings.RegistrySettingsMap = map[string]bool{}
 		t.Run(tt.name, func(t *testing.T) {
-			got := cisregistrysettings.CheckPoliciesHKLM(tt.key)
-			if len(got) != len(tt.want) {
-				t.Errorf("Length of CheckPoliciesHKLM() = %v, want %v", len(got), len(tt.want))
-			}
-			for i, result := range got {
-				if result != tt.want[i] {
-					t.Errorf("CheckPoliciesHKLM() at index %v = %v, want %v", i, result, tt.want[i])
-				}
+			cisregistrysettings.CheckPoliciesHKLM(tt.key)
+			if cisregistrysettings.RegistrySettingsMap[`SOFTWARE\Microsoft\Windows\Currentversion\Policies\Credui\EnumerateAdministrators`] != tt.want {
+				t.Errorf("CheckPoliciesHKLM() = %v, want %v", allValuesTrue(cisregistrysettings.RegistrySettingsMap), tt.want)
 			}
 		})
 	}
@@ -499,6 +455,7 @@ func TestCISRegistrySettings(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		cisregistrysettings.RegistrySettingsMap = map[string]bool{}
 		t.Run(tt.name, func(t *testing.T) {
 			got := cisregistrysettings.CISRegistrySettings(tt.lmKey, tt.usrKey)
 			if got.Result[0] != tt.want.Result[0] {
@@ -517,7 +474,7 @@ func TestCheckIntegerStringRegistrySettings(t *testing.T) {
 		expectedIntegers []interface{}
 		stringSettings   []string
 		expectedStrings  []string
-		want             []bool
+		want             bool
 	}{
 		{
 			name:             "Check nothing",
@@ -527,7 +484,7 @@ func TestCheckIntegerStringRegistrySettings(t *testing.T) {
 			expectedIntegers: []interface{}{},
 			stringSettings:   []string{},
 			expectedStrings:  []string{},
-			want:             make([]bool, 0),
+			want:             false,
 		},
 		{
 			name: "Check some int and string setting",
@@ -545,12 +502,16 @@ func TestCheckIntegerStringRegistrySettings(t *testing.T) {
 			expectedIntegers: []interface{}{uint64(0)},
 			stringSettings:   []string{"EnumerateAdministrators"},
 			expectedStrings:  []string{"0"},
-			want:             []bool{true, true},
+			want:             true,
 		},
 	}
 	for _, tt := range tests {
+		cisregistrysettings.RegistrySettingsMap = map[string]bool{}
 		t.Run(tt.name, func(t *testing.T) {
 			cisregistrysettings.CheckIntegerStringRegistrySettings(tt.key, tt.path, tt.integerSettings, tt.expectedIntegers, tt.stringSettings, tt.expectedStrings)
+			if allValuesTrue(cisregistrysettings.RegistrySettingsMap) != tt.want {
+				t.Errorf("CheckIntegerStringRegistrySettings() = %v, want %v", allValuesTrue(cisregistrysettings.RegistrySettingsMap), tt.want)
+			}
 		})
 	}
 }
@@ -562,7 +523,7 @@ func TestCheckStringRegistrySettings(t *testing.T) {
 		path            string
 		stringSettings  []string
 		expectedStrings []string
-		want            []bool
+		want            bool
 	}{
 		{
 			name:            "Check nothing",
@@ -570,7 +531,7 @@ func TestCheckStringRegistrySettings(t *testing.T) {
 			path:            "",
 			stringSettings:  []string{},
 			expectedStrings: []string{},
-			want:            make([]bool, 0),
+			want:            false,
 		},
 		{
 			name: "Check some string setting",
@@ -585,12 +546,16 @@ func TestCheckStringRegistrySettings(t *testing.T) {
 			path:            "SOFTWARE\\Microsoft\\Windows\\Currentversion\\Policies\\Credui",
 			stringSettings:  []string{"EnumerateAdministrators"},
 			expectedStrings: []string{"0"},
-			want:            []bool{true},
+			want:            true,
 		},
 	}
 	for _, tt := range tests {
+		cisregistrysettings.RegistrySettingsMap = map[string]bool{}
 		t.Run(tt.name, func(t *testing.T) {
 			cisregistrysettings.CheckStringRegistrySettings(tt.key, tt.path, tt.stringSettings, tt.expectedStrings)
+			if allValuesTrue(cisregistrysettings.RegistrySettingsMap) != tt.want {
+				t.Errorf("CheckStringRegistrySettings() = %v, want %v", allValuesTrue(cisregistrysettings.RegistrySettingsMap), tt.want)
+			}
 		})
 	}
 }
@@ -602,7 +567,7 @@ func TestCheckIntegerRegistrySettings(t *testing.T) {
 		path             string
 		integerSettings  []string
 		expectedIntegers []interface{}
-		want             []bool
+		want             bool
 	}{
 		{
 			name:             "Check nothing",
@@ -610,7 +575,7 @@ func TestCheckIntegerRegistrySettings(t *testing.T) {
 			path:             "",
 			integerSettings:  []string{},
 			expectedIntegers: []interface{}{},
-			want:             make([]bool, 0),
+			want:             false,
 		},
 		{
 			name: "Check some integer setting",
@@ -625,85 +590,15 @@ func TestCheckIntegerRegistrySettings(t *testing.T) {
 			path:             "SOFTWARE\\Microsoft\\Windows\\Currentversion\\Policies\\Credui",
 			integerSettings:  []string{"EnumerateAdministrators"},
 			expectedIntegers: []interface{}{uint64(0)},
-			want:             []bool{true},
+			want:             true,
 		},
 	}
 	for _, tt := range tests {
+		cisregistrysettings.RegistrySettingsMap = map[string]bool{}
 		t.Run(tt.name, func(t *testing.T) {
 			cisregistrysettings.CheckIntegerRegistrySettings(tt.key, tt.path, tt.integerSettings, tt.expectedIntegers)
-		})
-	}
-}
-
-func TestCheckMultipleStringValues(t *testing.T) {
-	tests := []struct {
-		name            string
-		key             mocking.RegistryKey
-		stringSettings  []string
-		expectedStrings []string
-		want            []bool
-	}{
-		{
-			name:            "Check nothing",
-			key:             &mocking.MockRegistryKey{},
-			stringSettings:  []string{},
-			expectedStrings: []string{},
-			want:            make([]bool, 0),
-		},
-		{
-			name: "Check some string settings",
-			key: &mocking.MockRegistryKey{
-				StringValues: map[string]string{"EnumerateAdministrators": "0", "EnumerateUsers": "1"},
-			},
-			stringSettings:  []string{"EnumerateAdministrators", "EnumerateUsers"},
-			expectedStrings: []string{"0", "1"},
-			want:            []bool{true, true},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := cisregistrysettings.CheckMultipleStringValues(tt.key, tt.stringSettings, tt.expectedStrings)
-			for i, result := range got {
-				if result != tt.want[i] {
-					t.Errorf("CheckMultipleStringValues() at index %v = %v, want %v", i, result, tt.want[i])
-				}
-			}
-		})
-	}
-}
-
-func TestCheckMultipleIntegerValues(t *testing.T) {
-	tests := []struct {
-		name             string
-		key              mocking.RegistryKey
-		integerSettings  []string
-		expectedIntegers []interface{}
-		want             []bool
-	}{
-		{
-			name:             "Check nothing",
-			key:              &mocking.MockRegistryKey{},
-			integerSettings:  []string{},
-			expectedIntegers: []interface{}{},
-			want:             make([]bool, 0),
-		},
-		{
-			name: "Check some integer setting",
-			key: &mocking.MockRegistryKey{
-				IntegerValues: map[string]uint64{"EnumerateAdministrators": uint64(0), "EnumerateUsers": uint64(1)},
-			},
-			integerSettings:  []string{"EnumerateAdministrators"},
-			expectedIntegers: []interface{}{uint64(0), uint64(1)},
-			want:             []bool{true, true},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := cisregistrysettings.CheckMultipleIntegerValues(tt.key, tt.integerSettings, tt.expectedIntegers)
-			for i, result := range got {
-				if result != tt.want[i] {
-					t.Errorf("CheckMultipleIntegerValues() at index %v = %v, want %v", i, result, tt.want[i])
-				}
+			if allValuesTrue(cisregistrysettings.RegistrySettingsMap) != tt.want {
+				t.Errorf("CheckIntegerRegistrySettings() = %v, want %v", allValuesTrue(cisregistrysettings.RegistrySettingsMap), tt.want)
 			}
 		})
 	}
@@ -725,6 +620,7 @@ func TestOpenRegistryKeyWithErrHandling(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		cisregistrysettings.RegistrySettingsMap = map[string]bool{}
 		t.Run(tt.name, func(t *testing.T) {
 			got, _ := cisregistrysettings.OpenRegistryKeyWithErrHandling(tt.key, tt.path)
 			if got != nil && tt.want == false {
@@ -802,4 +698,17 @@ func TestCheckIntegerValue(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Helper function to check if all values in a map are true
+func allValuesTrue(m map[string]bool) bool {
+	if (len(m)) == 0 {
+		return false
+	}
+	for _, value := range m {
+		if !value {
+			return false
+		}
+	}
+	return true
 }

--- a/checks/cisregistrysettings/cis_registry_win10_specific.go
+++ b/checks/cisregistrysettings/cis_registry_win10_specific.go
@@ -10,9 +10,7 @@ import "github.com/InfoSec-Agent/InfoSec-Agent/mocking"
 //
 //   - registryKey (mocking.RegistryKey): The root key from which the registry settings will be checked. Should be HKEY_LOCAL_MACHINE for this function.
 //
-// Returns:
-//
-//   - []bool: A slice of boolean values, where each boolean represents whether a particular registry setting adheres to the CIS Benchmark standards.
+// Returns: None
 func CheckWin10(registryKey mocking.RegistryKey) {
 	for _, check := range checksWin10 {
 		check(registryKey)

--- a/checks/cisregistrysettings/cis_registry_win10_specific.go
+++ b/checks/cisregistrysettings/cis_registry_win10_specific.go
@@ -13,14 +13,10 @@ import "github.com/InfoSec-Agent/InfoSec-Agent/mocking"
 // Returns:
 //
 //   - []bool: A slice of boolean values, where each boolean represents whether a particular registry setting adheres to the CIS Benchmark standards.
-func CheckWin10(registryKey mocking.RegistryKey) []bool {
-	results := make([]bool, 0)
-
+func CheckWin10(registryKey mocking.RegistryKey) {
 	for _, check := range checksWin10 {
 		check(registryKey)
 	}
-
-	return results
 }
 
 // checksWin10 is a collection of registry checks specific to the Windows 10 CIS Benchmark Audit list.

--- a/checks/cisregistrysettings/cis_registry_win10_specific.go
+++ b/checks/cisregistrysettings/cis_registry_win10_specific.go
@@ -17,7 +17,7 @@ func CheckWin10(registryKey mocking.RegistryKey) []bool {
 	results := make([]bool, 0)
 
 	for _, check := range checksWin10 {
-		results = append(results, check(registryKey)...)
+		check(registryKey)
 	}
 
 	return results
@@ -26,7 +26,7 @@ func CheckWin10(registryKey mocking.RegistryKey) []bool {
 // checksWin10 is a collection of registry checks specific to the Windows 10 CIS Benchmark Audit list.
 // Each function in the collection represents a different registry setting check that the application can perform.
 // The registry settings get checked against the CIS Benchmark recommendations.
-var checksWin10 = []func(mocking.RegistryKey) []bool{
+var checksWin10 = []func(mocking.RegistryKey){
 	win10Print,
 	win10DNSClient,
 	win10Printers,
@@ -40,49 +40,47 @@ var checksWin10 = []func(mocking.RegistryKey) []bool{
 // win10Print is a helper function that checks the registry to determine if the system is configured with the correct settings for the Print control.
 //
 // CIS Benchmark Audit list index: 18.4.2
-func win10Print(registryKey mocking.RegistryKey) []bool {
+func win10Print(registryKey mocking.RegistryKey) {
 	registryPath := `SYSTEM\CurrentControlSet\Control\Print`
 
 	settings := []string{"RpcAuthnLevelPrivacyEnabled"}
 
 	expectedValues := []interface{}{uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // wind10DNSClient is a helper function that checks the registry to determine if the system is configured with the correct settings for the DNS Client.
 //
 // CIS Benchmark Audit list index: 18.6.4.1
-func win10DNSClient(registryKey mocking.RegistryKey) []bool {
+func win10DNSClient(registryKey mocking.RegistryKey) {
 	registryPath := DNSClientRegistryPath
 
 	settings := []string{"EnableNetbios"}
 
 	expectedValues := []interface{}{uint64(2)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // win10Printers is a helper function that checks the registry to determine if the system is configured with the correct settings for the Printers.
 //
 // CIS Benchmark Audit list index: 18.7.2-7 18.7.9
-func win10Printers(registryKey mocking.RegistryKey) []bool {
-	results := make([]bool, 0)
+func win10Printers(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows NT\Printers`
 
 	settings := []string{"RedirectionGuardPolicy", "CopyFilesPolicy"}
 
 	expectedValues := []interface{}{uint64(1), uint64(1)}
 
-	results = append(results, CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)...)
-	results = append(results, win10PrintersRPC(registryKey)...)
-	return results
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	win10PrintersRPC(registryKey)
 }
 
 // win10PrintersRPC is a helper function that checks the registry to determine if the system is configured with the correct settings for the Printers RPC.
 //
 // CIS Benchmark Audit list index: 18.7.3-7
-func win10PrintersRPC(registryKey mocking.RegistryKey) []bool {
+func win10PrintersRPC(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows NT\Printers\RPC`
 
 	settings := []string{"RpcUseNamedPipeProtocol", "RpcAuthentication",
@@ -90,26 +88,26 @@ func win10PrintersRPC(registryKey mocking.RegistryKey) []bool {
 
 	expectedValues := []interface{}{uint64(0), uint64(0), uint64(5), uint64(0), uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // win10System is a helper function that checks the registry to determine if the system is configured with the correct settings for the System.
 //
 // CIS Benchmark Audit list index: 18.9.25.1
-func win10System(registryKey mocking.RegistryKey) []bool {
+func win10System(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\System`
 
 	settings := []string{"AllowCustomSSPsAPs"}
 
 	expectedValues := []interface{}{uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // win10AppInstaller is a helper function that checks the registry to determine if the system is configured with the correct settings for the AppInstaller.
 //
 // CIS Benchmark Audit list indices: 18.10.17.1-4
-func win10AppInstaller(registryKey mocking.RegistryKey) []bool {
+func win10AppInstaller(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows\AppInstaller`
 
 	settings := []string{"EnableAppInstaller", "EnableExperimentalFeatures",
@@ -117,44 +115,44 @@ func win10AppInstaller(registryKey mocking.RegistryKey) []bool {
 
 	expectedValues := []interface{}{uint64(0), uint64(0), uint64(0), uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // win10InternetExplorerMain is a helper function that checks the registry to determine if the system is configured with the correct settings for Internet Explorer
 //
 // CIS Benchmark Audit list index: 18.10.35.1
-func win10InternetExplorerMain(registryKey mocking.RegistryKey) []bool {
+func win10InternetExplorerMain(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Internet Explorer\Main`
 
 	settings := []string{"NotifyDisableIEOptions"}
 
 	expectedValues := []interface{}{uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // win10ExploitGuardRules is a helper function that checks the registry to determine if the system is configured with the correct settings for the Exploit Guard Rules.
 //
 // CIS Benchmark Audit list index: 18.10.43.6.1.2
-func win10ExploitGuardRules(registryKey mocking.RegistryKey) []bool {
+func win10ExploitGuardRules(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules`
 
 	settings := []string{"56a863a9-875e-4185-98a7-b882c64b5ce5"}
 
 	expectedValues := []interface{}{uint64(1)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }
 
 // win10PoliciesSystem is a helper function that checks the registry to determine if the system is configured with the correct policy settings for the System.
 //
 // CIS Benchmark Audit list index: 18.10.82.1
-func win10PoliciesSystem(registryKey mocking.RegistryKey) []bool {
+func win10PoliciesSystem(registryKey mocking.RegistryKey) {
 	registryPath := `SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System`
 
 	settings := []string{"EnableMPR"}
 
 	expectedValues := []interface{}{uint64(0)}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }

--- a/checks/cisregistrysettings/cis_registry_win11_specific.go
+++ b/checks/cisregistrysettings/cis_registry_win11_specific.go
@@ -17,7 +17,7 @@ func CheckWin11(registryKey mocking.RegistryKey) []bool {
 	results := make([]bool, 0)
 
 	for _, check := range checksWin11 {
-		results = append(results, check(registryKey)...)
+		check(registryKey)
 	}
 
 	return results
@@ -26,19 +26,19 @@ func CheckWin11(registryKey mocking.RegistryKey) []bool {
 // checksWin11 is a collection of registry checks specific to the Windows 11 CIS Benchmark Audit list.
 // Each function in the collection represents a different registry setting check that the application can perform.
 // The registry settings get checked against the CIS Benchmark recommendations.
-var checksWin11 = []func(mocking.RegistryKey) []bool{
+var checksWin11 = []func(mocking.RegistryKey){
 	win11DNSClient,
 }
 
 // win11DNSClient is a helper function that checks the registry to determine if the system is configured with the correct settings for the DNS Client.
 //
 // CIS Benchmark Audit list index: 18.5.4.1
-func win11DNSClient(registryKey mocking.RegistryKey) []bool {
+func win11DNSClient(registryKey mocking.RegistryKey) {
 	registryPath := DNSClientRegistryPath
 
 	settings := []string{"DoHPolicy"}
 
 	expectedValues := []interface{}{[]uint64{2, 3}}
 
-	return CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
+	CheckIntegerRegistrySettings(registryKey, registryPath, settings, expectedValues)
 }

--- a/checks/cisregistrysettings/cis_registry_win11_specific.go
+++ b/checks/cisregistrysettings/cis_registry_win11_specific.go
@@ -10,9 +10,7 @@ import "github.com/InfoSec-Agent/InfoSec-Agent/mocking"
 //
 //   - registryKey (mocking.RegistryKey): The root key from which the registry settings will be checked. Should be HKEY_LOCAL_MACHINE for this function.
 //
-// Returns:
-//
-//   - []bool: A slice of boolean values, where each boolean represents whether a particular registry setting adheres to the CIS Benchmark standards.
+// Returns: None
 func CheckWin11(registryKey mocking.RegistryKey) {
 	for _, check := range checksWin11 {
 		check(registryKey)

--- a/checks/cisregistrysettings/cis_registry_win11_specific.go
+++ b/checks/cisregistrysettings/cis_registry_win11_specific.go
@@ -13,14 +13,10 @@ import "github.com/InfoSec-Agent/InfoSec-Agent/mocking"
 // Returns:
 //
 //   - []bool: A slice of boolean values, where each boolean represents whether a particular registry setting adheres to the CIS Benchmark standards.
-func CheckWin11(registryKey mocking.RegistryKey) []bool {
-	results := make([]bool, 0)
-
+func CheckWin11(registryKey mocking.RegistryKey) {
 	for _, check := range checksWin11 {
 		check(registryKey)
 	}
-
-	return results
 }
 
 // checksWin11 is a collection of registry checks specific to the Windows 11 CIS Benchmark Audit list.

--- a/checks/cisregistrysettings/cis_registrysettings.go
+++ b/checks/cisregistrysettings/cis_registrysettings.go
@@ -183,6 +183,7 @@ func CheckIntegerRegistrySettings(registryKey mocking.RegistryKey, registryPath 
 	if err != nil {
 		for _, setting := range settings {
 			RegistrySettingsMap[registryPath+"\\"+setting] = false
+			return
 		}
 	}
 	defer mocking.CloseRegistryKey(key)
@@ -209,6 +210,7 @@ func CheckStringRegistrySettings(registryKey mocking.RegistryKey, registryPath s
 	if err != nil {
 		for _, setting := range settings {
 			RegistrySettingsMap[registryPath+"\\"+setting] = false
+			return
 		}
 	}
 	defer mocking.CloseRegistryKey(key)
@@ -243,6 +245,7 @@ func CheckIntegerStringRegistrySettings(registryKey mocking.RegistryKey, registr
 		for _, setting := range stringSettings {
 			RegistrySettingsMap[registryPath+"\\"+setting] = false
 		}
+		return
 	}
 	defer mocking.CloseRegistryKey(key)
 

--- a/checks/cisregistrysettings/cis_registrysettings.go
+++ b/checks/cisregistrysettings/cis_registrysettings.go
@@ -220,6 +220,11 @@ func CheckIntegerStringRegistrySettings(registryKey mocking.RegistryKey, registr
 	}
 }
 
+// getIncorrectSettings iterates over the RegistrySettingsMap and returns a slice of incorrect settings.
+//
+// Parameters: None
+//
+// Returns: None
 func getIncorrectSettings() (bool, []string) {
 	var incorrectSettings []string
 	fullyTrue := true

--- a/checks/cisregistrysettings/cis_registrysettings.go
+++ b/checks/cisregistrysettings/cis_registrysettings.go
@@ -6,10 +6,11 @@
 package cisregistrysettings
 
 import (
+	"slices"
+
 	"github.com/InfoSec-Agent/InfoSec-Agent/checks"
 	"github.com/InfoSec-Agent/InfoSec-Agent/logger"
 	"github.com/InfoSec-Agent/InfoSec-Agent/mocking"
-	"slices"
 )
 
 const DNSClientRegistryPath = `SOFTWARE\Policies\Microsoft\Windows NT\DNSClient`

--- a/checks/cisregistrysettings/cis_registrysettings.go
+++ b/checks/cisregistrysettings/cis_registrysettings.go
@@ -15,6 +15,8 @@ import (
 
 const DNSClientRegistryPath = `SOFTWARE\Policies\Microsoft\Windows NT\DNSClient`
 
+// RegistrySettingsMap is a map that stores the results of the registry settings checks.
+// The key is the registry path and the value is a boolean indicating whether the registry setting adheres to the CIS Benchmark standards.
 var RegistrySettingsMap = map[string]bool{}
 
 // CISRegistrySettings is a function that checks various registry settings to ensure they adhere to the CIS Benchmark standards.
@@ -27,7 +29,7 @@ var RegistrySettingsMap = map[string]bool{}
 //
 // Returns:
 //
-//   - []bool: A slice of boolean values, where each boolean represents whether a particular registry setting adheres to the CIS Benchmark standards.
+//   - checks.Check: A check object containing the settings that do not adhere to the CIS Benchmark standards.
 func CISRegistrySettings(localMachineKey mocking.RegistryKey, usersKey mocking.RegistryKey) checks.Check {
 	// Following function(s) need the HKEY_LOCAL_MACHINE registry key
 	CheckServices(localMachineKey)
@@ -139,9 +141,7 @@ func OpenRegistryKeyWithErrHandling(registryKey mocking.RegistryKey, path string
 //   - settings ([]string): A slice of strings representing the names of the values to check.
 //   - expectedValues ([]interface{}): A slice of interface values representing the expected values of the registry keys.
 //
-// Returns:
-//
-//   - []bool: A slice of boolean values indicating whether the integer settings of the registry keys match the expected values.
+// Returns: None
 func CheckIntegerRegistrySettings(registryKey mocking.RegistryKey, registryPath string, settings []string, expectedValues []interface{}) {
 	key, err := OpenRegistryKeyWithErrHandling(registryKey, registryPath)
 	if err != nil {
@@ -166,9 +166,7 @@ func CheckIntegerRegistrySettings(registryKey mocking.RegistryKey, registryPath 
 //   - settings ([]string): A slice of strings representing the names of the values to check.
 //   - expectedValues ([]string): A slice of strings representing the expected values of the registry keys.
 //
-// Returns:
-//
-//   - []bool: A slice of boolean values indicating whether the string settings of the registry keys match the expected values.
+// Returns: None
 func CheckStringRegistrySettings(registryKey mocking.RegistryKey, registryPath string, settings []string, expectedValues []string) {
 	key, err := OpenRegistryKeyWithErrHandling(registryKey, registryPath)
 	if err != nil {
@@ -195,9 +193,7 @@ func CheckStringRegistrySettings(registryKey mocking.RegistryKey, registryPath s
 //   - stringSettings ([]string): A slice of strings representing the names of the string values to check.
 //   - expectedStrings ([]string): A slice of strings representing the expected string values of the registry keys.
 //
-// Returns:
-//
-//   - []bool: A slice of boolean values indicating whether the integer and string settings of the registry keys match the expected values.
+// Returns: None
 func CheckIntegerStringRegistrySettings(registryKey mocking.RegistryKey, registryPath string,
 	integerSettings []string, expectedIntegers []interface{}, stringSettings []string,
 	expectedStrings []string) {
@@ -225,7 +221,10 @@ func CheckIntegerStringRegistrySettings(registryKey mocking.RegistryKey, registr
 //
 // Parameters: None
 //
-// Returns: None
+// Returns:
+//
+//   - bool: A boolean value indicating whether all registry settings adhere to the CIS Benchmark standards.
+//   - []string: A slice of strings representing the incorrect registry settings.
 func getIncorrectSettings() (bool, []string) {
 	var incorrectSettings []string
 	fullyTrue := true


### PR DESCRIPTION
Now uses a global variable RegistrySettingsMap that each registry setting check now updates. Also now passes all settings that do not adhere to the CIS Audit list as a result.