### PR TITLE
V24A-517 Move usersettings to AppData folder

### DIFF
--- a/backend/scan/scan.go
+++ b/backend/scan/scan.go
@@ -152,7 +152,7 @@ func Scan(dialog zenity.ProgressDialog) ([]checks.Check, error) {
 	logger.Log.Info(string(jsonData))
 
 	// TODO: Set usersettings.Integration to true depending on whether user has connected with the API
-	if usersettings.LoadUserSettings("backend/usersettings").Integration {
+	if usersettings.LoadUserSettings().Integration {
 		integration.ParseScanResults(integration.Metadata{WorkStationID: workStationID, User: user, Date: date}, checkResults)
 	}
 	return checkResults, nil

--- a/backend/tray/tray.go
+++ b/backend/tray/tray.go
@@ -141,7 +141,7 @@ func OnReady() {
 				logger.Log.ErrorWithErr("Error scanning:", err)
 			}
 		case <-mChangeLanguage.ClickedCh:
-			ChangeLanguage("usersettings")
+			ChangeLanguage()
 			RefreshMenu()
 		case <-mQuit.ClickedCh:
 			systray.Quit()

--- a/backend/tray/tray.go
+++ b/backend/tray/tray.go
@@ -83,8 +83,8 @@ func OnReady() {
 	systray.SetIcon(icon.Data)
 	systray.SetTooltip("InfoSec Agent")
 
-	Language = usersettings.LoadUserSettings("backend/usersettings").Language
-	scanInterval := usersettings.LoadUserSettings("backend/usersettings").ScanInterval
+	Language = usersettings.LoadUserSettings().Language
+	scanInterval := usersettings.LoadUserSettings().ScanInterval
 
 	// Generate the menu for the system tray application
 	mReportingPage := systray.AddMenuItem(localization.Localize(Language, "Tray.ReportingPageTitle"),
@@ -298,9 +298,9 @@ func ChangeScanInterval(testInput ...string) {
 	ScanTicker = time.NewTicker(time.Duration(interval) * time.Hour)
 	logger.Log.Printf("Scan interval changed to %d hours\n", interval)
 	usersettings.SaveUserSettings(usersettings.UserSettings{
-		Language:     usersettings.LoadUserSettings("backend/usersettings").Language,
+		Language:     usersettings.LoadUserSettings().Language,
 		ScanInterval: interval,
-	}, "backend/usersettings")
+	})
 }
 
 // ScanNow initiates an immediate security scan, bypassing the scheduled intervals.
@@ -365,11 +365,10 @@ func ScanNow() ([]checks.Check, error) {
 //
 // Parameters:
 //
-//   - path string: The relative path to the user settings file. This is used to save the updated language setting.
 //   - testInput ...string: Optional parameter used for testing. If provided, the function uses this as the user's language selection instead of displaying the dialog window.
 //
 // Returns: None. The function updates the 'language' variable in-place.
-func ChangeLanguage(path string, testInput ...string) {
+func ChangeLanguage(testInput ...string) {
 	var res string
 	if len(testInput) > 0 {
 		res = testInput[0]
@@ -405,8 +404,8 @@ func ChangeLanguage(path string, testInput ...string) {
 	}
 	usersettings.SaveUserSettings(usersettings.UserSettings{
 		Language:     Language,
-		ScanInterval: usersettings.LoadUserSettings(path).ScanInterval,
-	}, path)
+		ScanInterval: usersettings.LoadUserSettings().ScanInterval,
+	})
 }
 
 // RefreshMenu updates the system tray menu items to reflect the current language setting.

--- a/backend/tray/tray_test.go
+++ b/backend/tray/tray_test.go
@@ -211,7 +211,7 @@ func TestChangeLang(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tray.ChangeLanguage("usersettings", tc.input)
+		tray.ChangeLanguage(tc.input)
 		require.Equal(t, tc.expectedIndex, tray.Language)
 	}
 }
@@ -228,7 +228,7 @@ func TestChangeLang(t *testing.T) {
 func TestRefreshMenu(t *testing.T) {
 	value1 := tray.MenuItems[0].MenuTitle
 	translation1 := localization.Localize(tray.Language, value1)
-	tray.ChangeLanguage("usersettings", "Spanish")
+	tray.ChangeLanguage("Spanish")
 	// Refresh the menu, then check if the translation is different
 	// RefreshMenu(MenuItems)
 	value2 := tray.MenuItems[0].MenuTitle

--- a/backend/usersettings/user_settings.go
+++ b/backend/usersettings/user_settings.go
@@ -18,25 +18,31 @@ type UserSettings struct {
 	Integration  bool `json:"Integration"`
 }
 
-// NewUserSettings creates a new UserSettings struct
-// TODO: Reformat with new doc standard
-// Parameters: _
+// LoadUserSettings loads the user settings from a JSON file in the Windows AppData folder.
 //
-// Returns: a pointer to a new UserSettings struct
-func NewUserSettings() *UserSettings {
-	return &UserSettings{
-		Language:     LoadUserSettings("usersettings").Language,
-		ScanInterval: LoadUserSettings("usersettings").ScanInterval,
+// The function uses the os package to get the path to the AppData folder, and reads the user settings from a file named "user_settings.json" in this folder.
+// If there is an error while getting the AppData folder path, reading the JSON data from the file, or unmarshalling the JSON data to a UserSettings struct,
+//
+// Parameters: None
+//
+// Returns:
+//   - settings (UserSettings): The loaded user settings. This is a UserSettings struct.
+func LoadUserSettings() UserSettings {
+	appDataPath, err := os.UserConfigDir()
+	if err != nil {
+		logger.Log.ErrorWithErr("Error getting user config directory:", err)
+		return UserSettings{Language: 1, ScanInterval: 24}
 	}
-}
+	dirPath := appDataPath + `\InfoSec-Agent`
+	err = os.MkdirAll(dirPath, os.ModePerm)
+	if err != nil {
+		logger.Log.ErrorWithErr("Error creating directory:", err)
+		return UserSettings{Language: 1, ScanInterval: 24}
+	}
 
-// LoadUserSettings loads the user setting from the user settings file
-// TODO: Reformat with new doc standard
-// Parameters: _
-//
-// Returns: language setting (int)
-func LoadUserSettings(path string) UserSettings {
-	data, err := os.ReadFile(path + "/user_settings.json")
+	filePath := dirPath + `\user_settings.json`
+
+	data, err := os.ReadFile(filePath)
 	if err != nil {
 		logger.Log.ErrorWithErr("Error reading user settings file:", err)
 		return UserSettings{Language: 1, ScanInterval: 24}
@@ -51,18 +57,36 @@ func LoadUserSettings(path string) UserSettings {
 	return settings
 }
 
-// SaveUserSettings saves the user setting(s) to the user settings file
-// TODO: Reformat with new doc standard
-// Parameters: lang (int) - the language setting to save
+// SaveUserSettings saves the user settings to a JSON file in the Windows AppData\Roaming folder.
 //
-// Returns: _
-func SaveUserSettings(settings UserSettings, path string) {
+// The function takes a UserSettings struct as input, which contains the user settings to be saved.
+// It uses the os package to get the path to the AppData folder, and saves the user settings to a file named "user_settings.json" in this folder.
+//
+// Parameters:
+//   - settings (UserSettings): The user settings to be saved.
+//
+// Returns: None
+func SaveUserSettings(settings UserSettings) {
+	appDataPath, err := os.UserConfigDir()
+	if err != nil {
+		logger.Log.ErrorWithErr("Error getting user config directory:", err)
+		return
+	}
+
+	dirPath := appDataPath + `\InfoSec-Agent`
+	err = os.MkdirAll(dirPath, os.ModePerm)
+	if err != nil {
+		logger.Log.ErrorWithErr("Error creating directory:", err)
+		return
+	}
+	filePath := dirPath + `\user_settings.json`
+
 	file, err := json.MarshalIndent(settings, "", " ")
 	if err != nil {
 		logger.Log.ErrorWithErr("Error marshalling user settings JSON:", err)
 		return
 	}
-	err = os.WriteFile(path+"/user_settings.json", file, 0600)
+	err = os.WriteFile(filePath, file, 0600)
 	if err != nil {
 		logger.Log.ErrorWithErr("Error writing user setting(s) to file:", err)
 	}

--- a/backend/usersettings/user_settings.go
+++ b/backend/usersettings/user_settings.go
@@ -28,12 +28,14 @@ type UserSettings struct {
 // Returns:
 //   - settings (UserSettings): The loaded user settings. This is a UserSettings struct.
 func LoadUserSettings() UserSettings {
+	logger.Log.Debug("Getting user config directory")
 	appDataPath, err := os.UserConfigDir()
 	if err != nil {
 		logger.Log.ErrorWithErr("Error getting user config directory:", err)
 		return UserSettings{Language: 1, ScanInterval: 24}
 	}
 	dirPath := appDataPath + `\InfoSec-Agent`
+	logger.Log.Debug("Creating/reading directory at:" + dirPath)
 	err = os.MkdirAll(dirPath, os.ModePerm)
 	if err != nil {
 		logger.Log.ErrorWithErr("Error creating directory:", err)
@@ -42,6 +44,7 @@ func LoadUserSettings() UserSettings {
 
 	filePath := dirPath + `\user_settings.json`
 
+	logger.Log.Debug("Reading user settings from file:" + filePath)
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		logger.Log.ErrorWithErr("Error reading user settings file:", err)
@@ -49,6 +52,7 @@ func LoadUserSettings() UserSettings {
 	}
 
 	var settings UserSettings
+	logger.Log.Debug("Unmarshalling user settings JSON")
 	err = json.Unmarshal(data, &settings)
 	if err != nil {
 		logger.Log.ErrorWithErr("Error unmarshalling user settings JSON:", err)
@@ -67,6 +71,7 @@ func LoadUserSettings() UserSettings {
 //
 // Returns: None
 func SaveUserSettings(settings UserSettings) {
+	logger.Log.Debug("Getting user config directory")
 	appDataPath, err := os.UserConfigDir()
 	if err != nil {
 		logger.Log.ErrorWithErr("Error getting user config directory:", err)
@@ -74,6 +79,7 @@ func SaveUserSettings(settings UserSettings) {
 	}
 
 	dirPath := appDataPath + `\InfoSec-Agent`
+	logger.Log.Debug("Creating/reading directory at:" + dirPath)
 	err = os.MkdirAll(dirPath, os.ModePerm)
 	if err != nil {
 		logger.Log.ErrorWithErr("Error creating directory:", err)
@@ -81,11 +87,13 @@ func SaveUserSettings(settings UserSettings) {
 	}
 	filePath := dirPath + `\user_settings.json`
 
+	logger.Log.Debug("Marshalling data to JSON")
 	file, err := json.MarshalIndent(settings, "", " ")
 	if err != nil {
 		logger.Log.ErrorWithErr("Error marshalling user settings JSON:", err)
 		return
 	}
+	logger.Log.Debug("Writing user settings to file:" + filePath)
 	err = os.WriteFile(filePath, file, 0600)
 	if err != nil {
 		logger.Log.ErrorWithErr("Error writing user setting(s) to file:", err)

--- a/reporting-page/main.go
+++ b/reporting-page/main.go
@@ -100,7 +100,7 @@ func main() {
 	database := NewDataBase()
 	customLogger := logger.Log
 	localization.Init("../backend/")
-	lang := usersettings.LoadUserSettings("../backend/usersettings").Language
+	lang := usersettings.LoadUserSettings().Language
 	tray.Language = lang
 
 	// Create a Wails application with the specified options


### PR DESCRIPTION
Usersettings are now stored in AppData\Roaming\InfoSec-Agent. The folder gets automatically created if it does not exist yet. The old usersettings.json (in usersettings folder) can be safely deleted.