### PR TITLE
Remove TestFindEntriesValidInput

### DIFF
--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -25,4 +25,4 @@ jobs:
     - name: Run tests
       # skip the integration_testing directory, because these tests are run on VM's with custom configurations
       # skip TestFindEntriesValidInput because it opens the registry, which is different in the GitHub Actions runner
-      run: go test -cover $(go list ./... | grep -v /backend/integration_testing) -skip TestFindEntriesValidInput
+      run: go test -cover $(go list ./... | grep -v /backend/integration_testing)

--- a/backend/checks/utils_test.go
+++ b/backend/checks/utils_test.go
@@ -92,24 +92,6 @@ func TestCloseRegistryKeyInvalidKey(_ *testing.T) {
 	checks.CloseRegistryKey(key)
 }
 
-// TestFindEntriesValidInput is a test function that validates the behavior of the FindEntries function when provided with valid input.
-//
-// Parameter:
-//   - t *testing.T: The testing framework instance used to run the test and report the results.
-//
-// This function does not return any values. It uses the testing framework to assert that the FindEntries function behaves as expected when provided with valid registry key and entries. Specifically, it checks that the function returns a non-empty list of entries. If the FindEntries function does not behave as expected, this test function will cause the test run to fail.
-func TestFindEntriesValidInput(t *testing.T) {
-	key, err := checks.OpenRegistryKey(mocking.CurrentUser,
-		`SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run`)
-	defer checks.CloseRegistryKey(key)
-	require.NoError(t, err)
-	require.NotNil(t, key)
-	entries, err := key.ReadValueNames(0)
-	require.NoError(t, err)
-	result := checks.FindEntries(entries, key)
-	require.NotEmpty(t, result)
-}
-
 // TestFindEntriesInvalidInput is a test function that validates the behavior of the FindEntries function when provided with invalid (empty) input.
 //
 // Parameter:


### PR DESCRIPTION
Test was always broken on vm's and now that we're starting integration tests, this test is never run anywhere anymore.