### PR TITLE
V24A-656 Not installed browsers fix

### DIFF
--- a/backend/integration_testing/chromium_integration.go
+++ b/backend/integration_testing/chromium_integration.go
@@ -56,29 +56,6 @@ func TestIntegrationExtensionsChromiumWithoutAdBlocker(t *testing.T) {
 	}
 }
 
-func TestIntegrationExtensionsChromiumNotInstalled(t *testing.T) {
-	tests := []struct {
-		name    string
-		browser string
-	}{
-		{
-			name:    "Chrome not installed",
-			browser: "Chrome",
-		},
-		{
-			name:    "Edge not installed",
-			browser: "Edge",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := chromium.ExtensionsChromium(tt.browser, browsers.RealDefaultDirGetter{}, chromium.RealExtensionIDGetter{}, chromium.ChromeExtensionNameGetter{})
-			require.NotEmpty(t, result)
-			require.Equal(t, -1, result.ResultID)
-		})
-	}
-}
-
 func TestIntegrationHistoryChromiumWithoutPhishing(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -127,29 +104,6 @@ func TestIntegrationHistoryChromiumWithPhishing(t *testing.T) {
 	}
 }
 
-func TestIntegrationHistoryChromiumNotInstalled(t *testing.T) {
-	tests := []struct {
-		name    string
-		browser string
-	}{
-		{
-			name:    "Chrome not installed",
-			browser: "Chrome",
-		},
-		{
-			name:    "Edge not installed",
-			browser: "Edge",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := chromium.HistoryChromium(tt.browser, browsers.RealDefaultDirGetter{}, chromium.RealCopyDBGetter{}, chromium.RealQueryDatabaseGetter{}, chromium.RealProcessQueryResultsGetter{}, browsers.RealPhishingDomainGetter{})
-			require.NotEmpty(t, result)
-			require.Equal(t, -1, result.ResultID)
-		})
-	}
-}
-
 func TestIntegrationSearchEngineChromiumWithSearchEngine(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -170,29 +124,6 @@ func TestIntegrationSearchEngineChromiumWithSearchEngine(t *testing.T) {
 			require.NotEmpty(t, result)
 			require.NotEqual(t, -1, result.ResultID)
 			require.Equal(t, 0, result.ResultID)
-		})
-	}
-}
-
-func TestIntegrationSearchEngineChromiumNotInstalled(t *testing.T) {
-	tests := []struct {
-		name    string
-		browser string
-	}{
-		{
-			name:    "Chrome not installed",
-			browser: "Chrome",
-		},
-		{
-			name:    "Edge not installed",
-			browser: "Edge",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := chromium.SearchEngineChromium(tt.browser, false, nil, browsers.RealDefaultDirGetter{})
-			require.NotEmpty(t, result)
-			require.Equal(t, -1, result.ResultID)
 		})
 	}
 }

--- a/backend/integration_testing/config_not_present_test.go
+++ b/backend/integration_testing/config_not_present_test.go
@@ -9,7 +9,6 @@ var testsNotPresent = []func(t *testing.T){
 	i.TestIntegrationFirefoxFolderNotExists,
 	// TODO: turn back on when the test is fixed
 	// i.TestIntegrationLoginMethodPasswordAndPIN,
-	i.TestIntegrationLoginMethodPasswordAndPIN,
 	// TODO: turn back on when the test is fixed
 	// i.TestIntegrationOutdatedWin10UpToDate,
 	i.TestIntegrationUACPartialEnabled,

--- a/backend/integration_testing/config_not_present_test.go
+++ b/backend/integration_testing/config_not_present_test.go
@@ -7,15 +7,6 @@ import (
 
 var testsNotPresent = []func(t *testing.T){
 	i.TestIntegrationFirefoxFolderNotExists,
-	// TODO: turn back on when the test is fixed
-	// i.TestIntegrationExtensionsChromiumNotInstalled,
-	// TODO: turn back on when the test is fixed
-	// i.TestIntegrationHistoryChromiumNotInstalled,
-	// TODO: turn back on when the test is fixed
-	// i.TestIntegrationSearchEngineChromiumNotInstalled,
-	i.TestIntegrationSearchEngineFirefoxNotInstalled,
-	i.TestIntegrationHistoryFirefoxNotInstalled,
-	i.TestIntegrationExtensionsFirefoxNotInstalled,
 	i.TestIntegrationLoginMethodPasswordAndPIN,
 	// TODO: turn back on when the test is fixed
 	// i.TestIntegrationOutdatedWin10UpToDate,

--- a/backend/integration_testing/firefox_integration.go
+++ b/backend/integration_testing/firefox_integration.go
@@ -24,14 +24,6 @@ func TestIntegrationExtensionsFirefoxWithoutAdBlocker(t *testing.T) {
 	require.Equal(t, 1, adblock.ResultID)
 }
 
-func TestIntegrationExtensionsFirefoxNotInstalled(t *testing.T) {
-	result, adblock := firefox.ExtensionFirefox(browsers.RealProfileFinder{})
-	require.NotEmpty(t, result)
-	require.NotEmpty(t, adblock)
-	require.Equal(t, -1, result.ResultID)
-	require.Equal(t, -1, adblock.ResultID)
-}
-
 func TestIntegrationHistoryFirefoxWithoutPhishing(t *testing.T) {
 	result := firefox.HistoryFirefox(browsers.RealProfileFinder{}, browsers.RealPhishingDomainGetter{}, firefox.RealQueryDatabaseGetter{}, firefox.RealProcessQueryResultsGetter{}, firefox.RealCopyDBGetter{})
 	require.NotEqual(t, -1, result.ResultID)
@@ -46,23 +38,11 @@ func TestIntegrationHistoryFirefoxWithPhishing(t *testing.T) {
 	require.Equal(t, 1, result.ResultID)
 }
 
-func TestIntegrationHistoryFirefoxNotInstalled(t *testing.T) {
-	result := firefox.HistoryFirefox(browsers.RealProfileFinder{}, browsers.RealPhishingDomainGetter{}, firefox.RealQueryDatabaseGetter{}, firefox.RealProcessQueryResultsGetter{}, firefox.RealCopyDBGetter{})
-	require.Equal(t, -1, result.ResultID)
-	require.NotEmpty(t, result)
-}
-
 func TestIntegrationSearchEngineFirefoxWithSearchEngine(t *testing.T) {
 	result := firefox.SearchEngineFirefox(browsers.RealProfileFinder{}, false, nil, nil)
 	require.NotEqual(t, -1, result.ResultID)
 	require.NotEmpty(t, result)
 	require.Equal(t, 0, result.ResultID)
-}
-
-func TestIntegrationSearchEngineFirefoxNotInstalled(t *testing.T) {
-	result := firefox.SearchEngineFirefox(browsers.RealProfileFinder{}, false, nil, nil)
-	require.Equal(t, -1, result.ResultID)
-	require.NotEmpty(t, result)
 }
 
 func TestIntegrationCookiesFirefoxWithCookies(t *testing.T) {

--- a/backend/scan/scan_list.go
+++ b/backend/scan/scan_list.go
@@ -31,16 +31,13 @@ const browserEdge = "Edge"
 var ChecksList = func() [][]func() checks.Check {
 	var checks [][]func() checks.Check
 	// Check for the presence of Firefox, Chrome, and Edge profiles. If so, add the corresponding checks
-	firefoxDir := GeneratePath("\\AppData\\Roaming\\Mozilla\\Firefox\\Profiles")
-	chromeDir := GeneratePath("\\AppData\\Local\\Google\\Chrome\\User Data\\Default")
-	edgeDir := GeneratePath("\\AppData\\Local\\Microsoft\\Edge\\User Data\\Default")
-	if DirectoryExists(firefoxDir) {
+	if CheckInstalled(mocking.LocalMachine, "firefox.exe") {
 		checks = append(checks, mozillaFirefoxChecks)
 	}
-	if DirectoryExists(chromeDir) {
+	if CheckInstalled(mocking.LocalMachine, "chrome.exe") {
 		checks = append(checks, googleChromeChecks)
 	}
-	if DirectoryExists(edgeDir) {
+	if CheckInstalled(mocking.LocalMachine, "msedge.exe") {
 		checks = append(checks, microsoftEdgeChecks)
 	}
 	checks = append(checks, cisChecks)
@@ -180,4 +177,17 @@ func GeneratePath(path string) string {
 		return ""
 	}
 	return homeDir + path
+}
+
+// CheckInstalled is a function that checks if a specific path is installed on the system.
+//
+// Parameters:
+//   - registryKey (mocking.RegistryKey): A mocker of a Windows registry key. This is used to simulate the behavior of the Windows registry for testing purposes.
+//   - path (string): The path to check for installation.
+//
+// Returns:
+//   - bool: A boolean value indicating whether the path is installed on the system or not.
+func CheckInstalled(registryKey mocking.RegistryKey, path string) bool {
+	_, err := checks.OpenRegistryKey(registryKey, `SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\`+path)
+	return err == nil
 }

--- a/backend/scan/scan_test.go
+++ b/backend/scan/scan_test.go
@@ -2,6 +2,7 @@ package scan_test
 
 import (
 	"database/sql"
+	"github.com/InfoSec-Agent/InfoSec-Agent/backend/mocking"
 	"os"
 	"testing"
 
@@ -232,4 +233,40 @@ func TestGeneratePath(t *testing.T) {
 	// Test that given no path, it returns the path to the current user's home directory
 	path = scan.GeneratePath("")
 	require.Equal(t, currHomeDir, path)
+}
+
+func TestCheckInstalled(t *testing.T) {
+	tests := []struct {
+		name string
+		key  mocking.RegistryKey
+		path string
+		want bool
+	}{
+		{
+			name: "Path that exists",
+			key: &mocking.MockRegistryKey{
+				SubKeys: []mocking.MockRegistryKey{
+					{KeyName: "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\msedge.exe"}},
+			},
+			path: "msedge.exe",
+			want: true,
+		},
+		{
+			name: "Path that does not exist",
+			key: &mocking.MockRegistryKey{
+				SubKeys: []mocking.MockRegistryKey{
+					{KeyName: "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\msedge.exe"}},
+			},
+			path: "chrome.exe",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := scan.CheckInstalled(tt.key, tt.path)
+			if got != tt.want {
+				t.Errorf("CheckInstalled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Removed integration tests for this because they are no longer added to the scan if the program is not installed.